### PR TITLE
Avoid ansible 2.3

### DIFF
--- a/ansible/roles/kolla/tasks/config.yml
+++ b/ansible/roles/kolla/tasks/config.yml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure the Kolla configuration directores exist
+- name: Ensure the Kolla configuration directories exist
   file:
     path: "{{ item }}"
     state: directory

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible>=2.2.0 # GPLv3
+ansible>=2.2.0,!=2.3 # GPLv3
 cliff>=2.5.0 # Apache
 netaddr!=0.7.16,>=0.7.13 # BSD
 PyYAML>=3.10.0 # MIT


### PR DESCRIPTION
Ansible 2.3 appears to be skipping a stat task in the bootstrap role, with hilarious consequences.