### PR TITLE
Junos support for ansible 2.3

### DIFF
--- a/ansible/group_vars/switches/junos
+++ b/ansible/group_vars/switches/junos
@@ -11,7 +11,7 @@ switch_junos_provider:
   username: "{{ ansible_user }}"
   password: "{{ ansible_ssh_pass|default(omit) }}"
   ssh_keyfile: "{{ ansible_ssh_private_key_file|default(omit) }}"
-  timeout: "{{ switch_junos_timeout|default(omit) }}"
+  timeout: "{{ switch_junos_timeout }}"
 
 ###############################################################################
 # Configuration format.

--- a/ansible/physical-network.yml
+++ b/ansible/physical-network.yml
@@ -40,7 +40,6 @@
 
     - role: junos-switch
       junos_switch_delegate_to: localhost
-      junos_switch_venv: "{{ lookup('env', 'VIRTUAL_ENV') }}"
       junos_switch_type: "{{ switch_type }}"
       junos_switch_provider: "{{ switch_junos_provider }}"
       junos_switch_config_format: "{{ switch_junos_config_format }}"

--- a/ansible/physical-network.yml
+++ b/ansible/physical-network.yml
@@ -26,7 +26,6 @@
     - role: ssh-known-host
 
     - role: dell-switch
-      dell_switch_delegate_to: localhost
       dell_switch_type: "{{ switch_type }}"
       dell_switch_provider: "{{ switch_dellos_provider }}"
       dell_switch_config: "{{ switch_config }}"
@@ -39,7 +38,6 @@
     - role: ssh-known-host
 
     - role: junos-switch
-      junos_switch_delegate_to: localhost
       junos_switch_type: "{{ switch_type }}"
       junos_switch_provider: "{{ switch_junos_provider }}"
       junos_switch_config_format: "{{ switch_junos_config_format }}"

--- a/ansible/roles/dell-switch/defaults/main.yml
+++ b/ansible/roles/dell-switch/defaults/main.yml
@@ -1,7 +1,4 @@
 ---
-# Host on which to execute DellOS Ansible modules.
-dell_switch_delegate_to:
-
 # Type of Dell switch. One of dellos6, dellos9.
 dell_switch_type:
 

--- a/ansible/roles/dell-switch/tasks/main.yml
+++ b/ansible/roles/dell-switch/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 - name: Ensure DellOS6 switches are configured
-  dellos6_config:
+  local_action:
+    module: dellos6_config
     provider: "{{ dell_switch_provider }}"
     src: dellos6-config.j2
-  delegate_to: "{{ dell_switch_delegate_to }}"
   when: "{{ dell_switch_type == 'dellos6' }}"
 
 - name: Ensure DellOS9 switches are configured
-  dellos9_config:
+  local_action:
+    module: dellos9_config
     provider: "{{ dell_switch_provider }}"
     src: dellos9-config.j2
-  delegate_to: "{{ dell_switch_delegate_to }}"
   when: "{{ dell_switch_type == 'dellos9' }}"

--- a/ansible/roles/junos-switch/defaults/main.yml
+++ b/ansible/roles/junos-switch/defaults/main.yml
@@ -1,7 +1,4 @@
 ---
-# Host on which to execute Junos Ansible modules.
-junos_switch_delegate_to:
-
 # Authentication provider information.
 junos_switch_provider:
 

--- a/ansible/roles/junos-switch/tasks/main.yml
+++ b/ansible/roles/junos-switch/tasks/main.yml
@@ -3,6 +3,8 @@
 # not seem to be possible to use ansible_python_interpreter in combination with
 # delegate_to. This should be investigated in future as modification of system
 # packages via pip is not ideal.
+
+# For ansible 2.2, Juniper specific python packages are required.
 - name: Ensure python dependencies are installed
   pip:
     name: "{{ item }}"
@@ -10,7 +12,19 @@
   with_items:
     - junos-eznc
     - jxmlease
+  when: ansible_version | version_compare('2.3', 'lt')
   become: True
+
+# For ansible 2.3+, only the NETCONF client ncclient is required. This must be
+# installed on the ansible control host where the ansible-connection subprocess
+# is executed.
+- name: Ensure python dependencies are installed
+  local_action:
+    module: pip
+    name: ncclient
+    virtualenv: "{{ lookup('env', 'VIRTUAL_ENV') | default(omit, true) }}"
+  when: ansible_version | version_compare('2.3', 'ge')
+  become: "{{ lookup('env', 'VIRTUAL_ENV') == None }}"
 
 - name: Ensure Juniper switches are configured
   junos_config:

--- a/ansible/roles/junos-switch/tasks/main.yml
+++ b/ansible/roles/junos-switch/tasks/main.yml
@@ -27,11 +27,11 @@
   become: "{{ lookup('env', 'VIRTUAL_ENV') == None }}"
 
 - name: Ensure Juniper switches are configured
-  junos_config:
+  local_action:
+    module: junos_config
     provider: "{{ junos_switch_provider }}"
     src: "{{ junos_switch_src }}"
     src_format: "{{ junos_switch_config_format }}"
-  delegate_to: "{{ junos_switch_delegate_to }}"
   vars:
     junos_switch_config_format_to_src:
       set: junos-config-set.j2


### PR DESCRIPTION
Configuration of juniper switches was broken following the switch to ansible 2.3. These changes fix that.