### PR TITLE
Change name of element for diskimage-builder

### DIFF
--- a/ansible/group_vars/all/bifrost
+++ b/ansible/group_vars/all/bifrost
@@ -22,7 +22,7 @@ kolla_bifrost_dib_os_release: "GenericCloud"
 # List of DIB elements.
 kolla_bifrost_dib_elements:
   - "disable-selinux"
-  - "serial-console"
+  - "enable-serial-console"
   - "vm"
 
 # DIB init element.


### PR DESCRIPTION
Error when try to initiate image build ==>
/bifrost-base-source/bifrost-base-archive-stackhpc-pike/playbooks/roles/bifrost-create-dib-image/tasks/main.yml:121
 diskimage_builder.element_dependencies.MissingElementException: Element 'serial-console' not found
 diskimage-builder version 2.9.1

Check on https://docs.openstack.org/diskimage-builder/latest/elements/enable-serial-console/README.html

serial-console => enable-serial-console