### PR TITLE
Physical network interface limit and --display

### DIFF
--- a/ansible/filter_plugins/switches.py
+++ b/ansible/filter_plugins/switches.py
@@ -15,6 +15,22 @@
 import six
 
 
+def switch_interface_config_select_name(switch_interface_config, names):
+    """Select and return all switch interfaces matching requested names.
+
+    :param switch_interface_config: Switch interface configuration dict
+    :param names: String or list of strings - interface names to match
+    """
+    if isinstance(names, six.string_types):
+        names = [names]
+
+    return {
+        name: config
+        for name, config in switch_interface_config.items()
+        if name in names
+    }
+
+
 def switch_interface_config_select_description(switch_interface_config, descriptions):
     """Select and return all switch interfaces matching requested descriptions.
 
@@ -32,10 +48,27 @@ def switch_interface_config_select_description(switch_interface_config, descript
     }
 
 
+def switch_interface_config_select_trunk(switch_interface_config):
+    """Select and return all switch interfaces which are trunk links.
+
+    Interfaces are assumed to be trunked, unless they have a ngs_trunk_port
+    item which is set to False.
+
+    :param switch_interface_config: Switch interface configuration dict
+    """
+    return {
+        name: config
+        for name, config in switch_interface_config.items()
+        if config.get('ngs_trunk_port', True)
+    }
+
+
 class FilterModule(object):
     """Switch filters."""
 
     def filters(self):
         return {
+            'switch_interface_config_select_name': switch_interface_config_select_name,
             'switch_interface_config_select_description': switch_interface_config_select_description,
+            'switch_interface_config_select_trunk': switch_interface_config_select_trunk,
         }

--- a/ansible/kolla-openstack.yml
+++ b/ansible/kolla-openstack.yml
@@ -134,7 +134,8 @@
                     'password': hostvars[item].ansible_ssh_pass,
                     'ngs_trunk_ports': (
                          hostvars[item].switch_interface_config |
-                         switch_interface_config_select_description(kolla_neutron_ml2_generic_switch_trunk_port_hosts)).keys() | join(',')
+                         switch_interface_config_select_description(kolla_neutron_ml2_generic_switch_trunk_port_hosts) |
+                         switch_interface_config_select_trunk()).keys() | join(',')
                   }]
               }}
           with_items: "{{ kolla_neutron_ml2_generic_switch_hosts }}"

--- a/ansible/physical-network.yml
+++ b/ansible/physical-network.yml
@@ -16,6 +16,9 @@
     # to configure in order to restrict configuration to a subset of
     # interfaces.
     physical_network_interface_description_limit: ''
+    # Set this variable to True in order to display the candidate switch
+    # configuration and exit without applying it.
+    physical_network_display: False
   tasks:
     - name: Fail if both interface name and description limits are specified
       fail:
@@ -29,6 +32,10 @@
     - name: Group hosts by their switch type
       group_by:
         key: "switches_of_type_{{ switch_type }}"
+
+    - name: Group hosts by whether display mode is set
+      group_by:
+        key: "switches_in_display_mode_{{ physical_network_display | bool }}"
 
     - name: Add discovery interface configuration when performing discovery
       set_fact:
@@ -50,8 +57,20 @@
              switch_interface_config_select_description(physical_network_interface_description_limit.split(",")) }}
       when: physical_network_interface_description_limit != ''
 
+- name: Display switch configuration
+  hosts: switches_in_display_mode_True
+  gather_facts: no
+  tasks:
+    - name: Display the candidate global switch configuration
+      debug:
+        var: switch_config
+
+    - name: Display the candidate switch interface configuration
+      debug:
+        var: switch_interface_config
+
 - name: Ensure DellOS physical switches are configured
-  hosts: switches_of_type_dellos6:switches_of_type_dellos9
+  hosts: switches_of_type_dellos6:switches_of_type_dellos9:&switches_in_display_mode_False
   gather_facts: no
   roles:
     - role: ssh-known-host
@@ -63,7 +82,7 @@
       dell_switch_interface_config: "{{ switch_interface_config }}"
 
 - name: Ensure Juniper physical switches are configured
-  hosts: switches_of_type_junos
+  hosts: switches_of_type_junos:&switches_in_display_mode_False
   gather_facts: no
   roles:
     - role: ssh-known-host

--- a/ansible/physical-network.yml
+++ b/ansible/physical-network.yml
@@ -2,13 +2,30 @@
 # Switch configuration depends on the type of switch, so groups hosts by their
 # switch type and apply tasks/roles to the relevant groups.
 
-- name: Group hosts by their switch type
+- name: Group hosts by their switch type and apply configuration filters
   hosts: switches
   gather_facts: no
   vars:
-    # Set this variable to True to configure of network for hardware discovery.
+    # Set this variable to True to configure the network for hardware
+    # discovery.
     physical_network_enable_discovery: False
+    # Set this variable to a comma-separated list of names of interfaces to
+    # configure in order to restrict configuration to a subset of interfaces.
+    physical_network_interface_limit: ''
+    # Set this variable to a comma-separated list of descriptions of interfaces
+    # to configure in order to restrict configuration to a subset of
+    # interfaces.
+    physical_network_interface_description_limit: ''
   tasks:
+    - name: Fail if both interface name and description limits are specified
+      fail:
+        msg: >
+          The interface name and interface description limits are mutually
+          exclusive.
+      when:
+        - physical_network_interface_limit != ''
+        - physical_network_interface_description_limit != ''
+
     - name: Group hosts by their switch type
       group_by:
         key: "switches_of_type_{{ switch_type }}"
@@ -18,6 +35,20 @@
         switch_interface_config: >
           {{ switch_interface_config | combine(switch_interface_config_discovery) }}
       when: "{{ physical_network_enable_discovery | bool }}"
+
+    - name: Restrict switch interfaces to requested subset by name
+      set_fact:
+        switch_interface_config: >
+          {{ switch_interface_config |
+             switch_interface_config_select_name(physical_network_interface_limit.split(",")) }}
+      when: physical_network_interface_limit != ''
+
+    - name: Restrict switch interfaces to requested subset by description
+      set_fact:
+        switch_interface_config: >
+          {{ switch_interface_config |
+             switch_interface_config_select_description(physical_network_interface_description_limit.split(",")) }}
+      when: physical_network_interface_description_limit != ''
 
 - name: Ensure DellOS physical switches are configured
   hosts: switches_of_type_dellos6:switches_of_type_dellos9

--- a/doc/source/deployment.rst
+++ b/doc/source/deployment.rst
@@ -50,6 +50,9 @@ The names or descriptions should be separated by commas.  This may be useful
 when adding compute nodes to an existing deployment, in order to avoid changing
 the configuration interfaces in use by active nodes.
 
+The ``display`` argument will display the candidate switch configuration,
+without actually applying it.
+
 Seed Hypervisor
 ===============
 

--- a/doc/source/deployment.rst
+++ b/doc/source/deployment.rst
@@ -40,6 +40,16 @@ The ``--enable-discovery`` argument enables a one-time configuration of ports
 attached to baremetal compute nodes to support hardware discovery via ironic
 inspector.
 
+It is possible to limit the switch interfaces that will be configured, either
+by interface name or interface description::
+
+    (kayobe) $ kayobe physical network configure --group <group> --interface-limit <interface names>
+    (kayobe) $ kayobe physical network configure --group <group> --interface-description-limit <interface descriptions>
+
+The names or descriptions should be separated by commas.  This may be useful
+when adding compute nodes to an existing deployment, in order to avoid changing
+the configuration interfaces in use by active nodes.
+
 Seed Hypervisor
 ===============
 

--- a/doc/source/release-notes.rst
+++ b/doc/source/release-notes.rst
@@ -11,6 +11,8 @@ Features
 * Adds ``--interface-limit`` and ``--interface-description-limit`` arguments to
   the ``kayobe physical network configure`` command.  These arguments allow
   configuration to be limited to a subset of switch interfaces.
+* Adds a ``display`` argument to ``kayobe physical network configure`` command.
+  This will output the candidate switch configuration without applying it.
 
 Upgrade Notes
 -------------

--- a/doc/source/release-notes.rst
+++ b/doc/source/release-notes.rst
@@ -5,6 +5,13 @@ Release Notes
 In Development
 ==============
 
+Features
+--------
+
+* Adds ``--interface-limit`` and ``--interface-description-limit`` arguments to
+  the ``kayobe physical network configure`` command.  These arguments allow
+  configuration to be limited to a subset of switch interfaces.
+
 Upgrade Notes
 -------------
 

--- a/kayobe/cli/commands.py
+++ b/kayobe/cli/commands.py
@@ -227,6 +227,9 @@ class PhysicalNetworkConfigure(KayobeAnsibleMixin, VaultMixin, Command):
         group = parser.add_argument_group("Physical Networking")
         group.add_argument("--group", required=True,
                            help="the Ansible group to apply configuration to")
+        group.add_argument("--display", action="store_true",
+                           help="display the candidate configuration and exit "
+                                "without applying it")
         group.add_argument("--enable-discovery", action="store_true",
                            help="configure the network for hardware discovery")
         group.add_argument("--interface-limit",
@@ -240,6 +243,7 @@ class PhysicalNetworkConfigure(KayobeAnsibleMixin, VaultMixin, Command):
     def take_action(self, parsed_args):
         self.app.LOG.debug("Configuring a physical network")
         extra_vars = {}
+        extra_vars["physical_network_display"] = parsed_args.display
         if parsed_args.enable_discovery:
             extra_vars["physical_network_enable_discovery"] = True
         if parsed_args.interface_limit:

--- a/kayobe/cli/commands.py
+++ b/kayobe/cli/commands.py
@@ -229,6 +229,12 @@ class PhysicalNetworkConfigure(KayobeAnsibleMixin, VaultMixin, Command):
                            help="the Ansible group to apply configuration to")
         group.add_argument("--enable-discovery", action="store_true",
                            help="configure the network for hardware discovery")
+        group.add_argument("--interface-limit",
+                           help="limit the switch interfaces to be configured "
+                                "by interface name")
+        group.add_argument("--interface-description-limit",
+                           help="limit the switch interfaces to be configured "
+                                "by interface description")
         return parser
 
     def take_action(self, parsed_args):
@@ -236,6 +242,12 @@ class PhysicalNetworkConfigure(KayobeAnsibleMixin, VaultMixin, Command):
         extra_vars = {}
         if parsed_args.enable_discovery:
             extra_vars["physical_network_enable_discovery"] = True
+        if parsed_args.interface_limit:
+            extra_vars["physical_network_interface_limit"] = (
+                parsed_args.interface_limit)
+        if parsed_args.interface_description_limit:
+            extra_vars["physical_network_interface_description_limit"] = (
+                parsed_args.interface_description_limit)
         self.run_kayobe_playbook(parsed_args, "ansible/physical-network.yml",
                                  limit=parsed_args.group,
                                  extra_vars=extra_vars)


### PR DESCRIPTION
* Allow limiting physical network interface configuration to subsets of interfaces.
* Add a --display argument to kayobe physical network configure