### PR TITLE
In latest Docker 17.05 restart-retires and unless-stopped are

### DIFF
--- a/ansible/roles/docker-registry/defaults/main.yml
+++ b/ansible/roles/docker-registry/defaults/main.yml
@@ -30,4 +30,4 @@ docker_registry_tag: "latest"
 docker_registry_image_full: "{{ docker_registry_image }}:{{ docker_registry_tag }}"
 
 docker_registry_restart_policy: "unless-stopped"
-docker_registry_restart_retries: 10
+#docker_registry_restart_retries:

--- a/ansible/roles/docker-registry/tasks/deploy.yml
+++ b/ansible/roles/docker-registry/tasks/deploy.yml
@@ -7,7 +7,7 @@
     privileged: "{{ item.value.privileged | default(omit) }}"
     read_only: "{{ item.value.read_only | default(omit) }}"
     restart_policy: "{{ docker_registry_restart_policy }}"
-    restart_retries: "{{ docker_registry_restart_retries }}"
+    restart_retries: "{{ docker_registry_restart_retries | default(omit) }}"
     state: "{{ (item.value.enabled and action != 'destroy') | ternary('started', 'absent') }}"
     volumes: "{{ item.value.volumes }}"
   with_dict: "{{ docker_registry_services }}"

--- a/ansible/roles/inspection-store/defaults/main.yml
+++ b/ansible/roles/inspection-store/defaults/main.yml
@@ -34,4 +34,4 @@ inspection_store_tag: "latest"
 inspection_store_image_full: "{{ inspection_store_image }}:{{ inspection_store_tag }}"
 
 inspection_store_restart_policy: "unless-stopped"
-inspection_store_restart_retries: 10
+#inspection_store_restart_retries:

--- a/ansible/roles/inspection-store/tasks/start.yml
+++ b/ansible/roles/inspection-store/tasks/start.yml
@@ -7,7 +7,7 @@
     privileged: "{{ item.value.privileged | default(omit) }}"
     read_only: "{{ item.value.read_only | default(omit) }}"
     restart_policy: "{{ inspection_store_restart_policy }}"
-    restart_retries: "{{ inspection_store_restart_retries }}"
+    restart_retries: "{{ inspection_store_restart_retries | default(omit) }}"
     state: "{{ item.value.enabled | ternary('started', 'absent') }}"
     volumes: "{{ item.value.volumes }}"
   with_dict: "{{ inspection_store_services }}"

--- a/ansible/roles/opensm/defaults/main.yml
+++ b/ansible/roles/opensm/defaults/main.yml
@@ -27,4 +27,4 @@ opensm_tag: "latest"
 opensm_image_full: "{{ opensm_image }}:{{ opensm_tag }}"
 
 opensm_restart_policy: "unless-stopped"
-opensm_restart_retries: 10
+#opensm_restart_retries:

--- a/ansible/roles/opensm/tasks/deploy.yml
+++ b/ansible/roles/opensm/tasks/deploy.yml
@@ -7,7 +7,7 @@
     privileged: "{{ item.value.privileged | default(omit) }}"
     read_only: "{{ item.value.read_only | default(omit) }}"
     restart_policy: "{{ opensm_restart_policy }}"
-    restart_retries: "{{ opensm_restart_retries }}"
+    restart_retries: "{{ opensm_restart_retries | default(omit) }}"
     state: "{{ (item.value.enabled and action != 'destroy') | ternary('started', 'absent') }}"
     volumes: "{{ item.value.volumes }}"
   with_dict: "{{ opensm_services }}"


### PR DESCRIPTION
mutually exclusive. Remove restart-retries where used.