### PR TITLE
Change kolla build configuration path variable

### DIFF
--- a/ansible/container-image-build.yml
+++ b/ansible/container-image-build.yml
@@ -37,7 +37,7 @@
         set -o pipefail &&
         source {{ kolla_venv }}/bin/activate &&
         kolla-build \
-        --config-dir {{ kolla_config_path }} \
+        --config-dir {{ kolla_build_config_path }} \
         {% if item.type is defined %}--type {{ item.type }}{% endif %} \
         {% if push_images | bool %}--push{% endif %} \
         {{ item.regexes }} 2>&1 | tee --append {{ kolla_build_log_path }}

--- a/ansible/group_vars/all/globals
+++ b/ansible/group_vars/all/globals
@@ -13,6 +13,9 @@ kayobe_config_path: "{{ lookup('env', 'KAYOBE_CONFIG_PATH') | default('/etc/kayo
 # Base path for kayobe state on remote hosts.
 base_path: "/opt/kayobe"
 
+# Path in which to store configuration on remote hosts.
+config_path: "{{ base_path ~ '/etc' }}"
+
 # Path in which to cache downloaded images on remote hosts.
 image_cache_path: "{{ base_path ~ '/images' }}"
 

--- a/ansible/group_vars/all/kolla
+++ b/ansible/group_vars/all/kolla
@@ -18,6 +18,9 @@ kolla_source_version: "stackhpc/pike"
 # Path to virtualenv in which to install kolla.
 kolla_venv: "{{ virtualenv_path ~ '/kolla' }}"
 
+# Path in which to generate kolla configuration.
+kolla_build_config_path: "{{ config_path ~ '/kolla' }}"
+
 ###############################################################################
 # Kolla-ansible installation.
 
@@ -37,14 +40,14 @@ kolla_ansible_source_version: "stackhpc/pike"
 # Path to virtualenv in which to install kolla-ansible.
 kolla_ansible_venv: "{{ lookup('env', 'KOLLA_VENV_PATH') | default(lookup('env', 'PWD') ~ '/venvs/kolla-ansible', true) }}"
 
-###############################################################################
-# Kolla & kolla-ansible configuration.
-
-# Path to Kolla configuration directory.
+# Path to Kolla-ansible configuration directory.
 kolla_config_path: "{{ lookup('env', 'KOLLA_CONFIG_PATH') | default('/etc/kolla', true) }}"
 
-# Path to Kolla node custom configuration directory.
+# Path to Kolla-ansible node custom configuration directory.
 kolla_node_custom_config_path: "{{ kolla_config_path }}/config"
+
+###############################################################################
+# Kolla configuration.
 
 # Kolla base container image distribution.
 kolla_base_distro: "centos"

--- a/ansible/inspection-store.yml
+++ b/ansible/inspection-store.yml
@@ -12,5 +12,4 @@
     - role: inspection-store
       inspection_store_enabled: "{{ inspector_store_enabled }}"
       inspection_store_port: "{{ inspector_store_port }}"
-      # FIXME: Use kayobe_config_path?
-      inspection_store_config_path: "/etc/kayobe/inspection-store"
+      inspection_store_config_path: "{{ config_path }}/inspection-store"

--- a/ansible/roles/kolla-build/defaults/main.yml
+++ b/ansible/roles/kolla-build/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Directory where Kolla config files will be installed.
-kolla_config_path:
+kolla_build_config_path:
 
 # Valid options are [ centos, fedora, oraclelinux, ubuntu ]
 kolla_base_distro:

--- a/ansible/roles/kolla-build/tasks/main.yml
+++ b/ansible/roles/kolla-build/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Ensure the Kolla build configuration files exist
   template:
     src: "{{ item.src }}"
-    dest: "{{ kolla_config_path }}/{{ item.dest }}"
+    dest: "{{ kolla_build_config_path }}/{{ item.dest }}"
     mode: 0644
   with_items:
     - { src: kolla-build.conf.j2, dest: kolla-build.conf }

--- a/ansible/roles/kolla-build/templates/kolla-build.conf.j2
+++ b/ansible/roles/kolla-build/templates/kolla-build.conf.j2
@@ -15,7 +15,7 @@ namespace={{ kolla_docker_namespace }}
 tag={{ kolla_openstack_release }}
 
 # Path to a file containing template overrides.
-template_override={{ kolla_config_path }}/template-override.j2
+template_override={{ kolla_build_config_path }}/template-override.j2
 
 {% for source_name, source_def in kolla_sources.items() %}
 [{{ source_name }}]

--- a/ansible/roles/kolla/defaults/main.yml
+++ b/ansible/roles/kolla/defaults/main.yml
@@ -16,7 +16,7 @@ kolla_source_version:
 kolla_venv: "{{ ansible_env['PWD'] }}/kolla-venv"
 
 # Directory where Kolla config files will be installed.
-kolla_config_path:
+kolla_build_config_path:
 
 # Kolla OpenStack release version. This should be a Docker image tag.
 kolla_openstack_release:

--- a/ansible/roles/kolla/tasks/config.yml
+++ b/ansible/roles/kolla/tasks/config.yml
@@ -8,4 +8,4 @@
     mode: 0750
   become: True
   with_items:
-    - "{{ kolla_config_path }}"
+    - "{{ kolla_build_config_path }}"

--- a/doc/source/release-notes.rst
+++ b/doc/source/release-notes.rst
@@ -12,6 +12,12 @@ Upgrade Notes
   to ``True``.  Management of the firewall by ironic inspector is important to
   ensure that DHCP offers are not made to nodes during provisioning by
   inspector's DHCP server.
+* Adds a variable ``config_path``, used to set the base path to configuration
+  on remote hosts. The default value is ``/opt/kayobe/etc``.
+* Modifies the variable used to configure the kolla build configuration path
+  from ``kolla_config_path`` to ``kolla_build_config_path``.  This provides a
+  cleaner separation of kolla and kolla-ansible configuration options. The
+  default value is ``{{ config_path }}/kolla``.
 
 Kayobe 3.0.0
 ============

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -20,6 +20,9 @@
 # Path to virtualenv in which to install kolla.
 #kolla_venv:
 
+# Path in which to generate kolla configuration.
+#kolla_build_config_path:
+
 ###############################################################################
 # Kolla-ansible installation.
 
@@ -39,14 +42,14 @@
 # Path to virtualenv in which to install kolla-ansible.
 #kolla_ansible_venv:
 
-###############################################################################
-# Kolla & kolla-ansible configuration.
-
-# Path to Kolla configuration directory.
+# Path to Kolla-ansible configuration directory.
 #kolla_config_path:
 
-# Path to Kolla node custom configuration directory.
+# Path to Kolla-ansible node custom configuration directory.
 #kolla_node_custom_config_path:
+
+###############################################################################
+# Kolla configuration.
 
 # Kolla base container image distribution.
 #kolla_base_distro:


### PR DESCRIPTION
Previously shared kolla-ansible's kolla_config_path, now uses
kolla_build_config_path.

Also adds a variable, config_path, which sets a base path for
configuration on the remote hosts.