### PR TITLE
Use kolla-ansible's default neutron ML2 mechanism drivers

### DIFF
--- a/ansible/group_vars/all/neutron
+++ b/ansible/group_vars/all/neutron
@@ -2,10 +2,9 @@
 ###############################################################################
 # Neutron configuration.
 
-# List of Neutron ML2 mechanism drivers to use.
+# List of Neutron ML2 mechanism drivers to use. If unset the kolla-ansible
+# defaults will be used.
 kolla_neutron_ml2_mechanism_drivers:
-  - openvswitch
-  - genericswitch
 
 # List of Neutron ML2 type drivers to use.
 kolla_neutron_ml2_type_drivers:

--- a/doc/source/release-notes.rst
+++ b/doc/source/release-notes.rst
@@ -25,6 +25,10 @@ Upgrade Notes
   to ``True``.  Management of the firewall by ironic inspector is important to
   ensure that DHCP offers are not made to nodes during provisioning by
   inspector's DHCP server.
+* The default list of neutron ML2 mechanism drivers
+  (``kolla_neutron_ml2_mechanism_drivers``) has been removed in favour of using
+  the defaults provided by kolla-ansible. Users relying on the default list of
+  ``openvswitch`` and ``genericswitch`` should set the value explicitly.
 
 Kayobe 3.0.0
 ============

--- a/etc/kayobe/neutron.yml
+++ b/etc/kayobe/neutron.yml
@@ -2,7 +2,8 @@
 ###############################################################################
 # Neutron configuration.
 
-# List of Neutron ML2 mechanism drivers to use.
+# List of Neutron ML2 mechanism drivers to use. If unset the kolla-ansible
+# defaults will be used.
 #kolla_neutron_ml2_mechanism_drivers:
 
 # List of Neutron ML2 type drivers to use.


### PR DESCRIPTION
The dependencies are not installed by default. The default list now
contains openvswitch only.