### PR TITLE
Set the Vagrant development VM's hostname

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,10 @@ Vagrant.configure("2") do |config|
   # `vagrant box outdated`. This is not recommended.
   # config.vm.box_check_update = false
 
+  # The default hostname is localhost, so set it to something a little more
+  # sensible.
+  config.vm.hostname = "controller1"
+
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.


### PR DESCRIPTION
By default the hostname will be localhost, which causes issues with RabbitMQ.