### PR TITLE
Add custom for dns interface

### DIFF
--- a/ansible/kolla-ansible.yml
+++ b/ansible/kolla-ansible.yml
@@ -38,6 +38,7 @@
             kolla_cluster_interface: "{{ storage_mgmt_net_name | net_interface(controller_host) | replace('-', '_') }}"
             kolla_provision_interface: "{{ provision_wl_net_name | net_interface(controller_host) | replace('-', '_') }}"
             kolla_inspector_dnsmasq_interface: "{{ provision_wl_net_name | net_interface(controller_host) | replace('-', '_') }}"
+            kolla_dns_interface: "{{ public_net_name | net_interface(controller_host) | replace('-', '_') }}"
 
         - name: Validate controller Kolla Ansible network configuration
           fail:

--- a/ansible/roles/kolla-ansible/defaults/main.yml
+++ b/ansible/roles/kolla-ansible/defaults/main.yml
@@ -121,6 +121,7 @@ kolla_external_vip_interface:
 kolla_api_interface:
 kolla_storage_interface:
 kolla_cluster_interface:
+kolla_dns_interface:
 
 # This is the raw interface given to neutron as its external network port. Even
 # though an IP address can exist on this interface, it will be unusable in most

--- a/ansible/roles/kolla-ansible/templates/globals.yml.j2
+++ b/ansible/roles/kolla-ansible/templates/globals.yml.j2
@@ -84,6 +84,7 @@ kolla_external_vip_interface: "{{ kolla_external_vip_interface }}"
 api_interface: "{{ kolla_api_interface }}"
 storage_interface: "{{ kolla_storage_interface }}"
 cluster_interface: "{{ kolla_cluster_interface }}"
+dns_interface: "{{ kolla_dns_interface }}"
 # NOTE: tunnel_interface is unused.
 
 # This is the raw interface given to neutron as its external network port. Even


### PR DESCRIPTION
By default, mdns listen on private network.

Designate MDNS node requires the dns_interface to be reachable from public network.