### PR TITLE
Add manila extra config path

### DIFF
--- a/ansible/roles/kolla-openstack/vars/main.yml
+++ b/ansible/roles/kolla-openstack/vars/main.yml
@@ -60,6 +60,11 @@ kolla_openstack_custom_config:
     dest: "{{ kolla_node_custom_config_path }}/magnum"
     patterns: "*"
     enabled: "{{ kolla_enable_magnum }}"
+  # Manila.
+  - src: "{{ kolla_extra_config_path }}/manila"
+    dest: "{{ kolla_node_custom_config_path }}/manila"
+    patterns: "*"
+    enabled: "{{ kolla_enable_manila }}"
   # Murano.
   - src: "{{ kolla_extra_config_path }}/murano"
     dest: "{{ kolla_node_custom_config_path }}/murano"


### PR DESCRIPTION
This extra config path is being used by the next external ceph
configuration for the native ceph backend.