### PR TITLE
[Vagrant] Support for VMware Fusion, fixes for container image builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ ansible/roles/yatesr.timezone/
 
 # Virtualenv
 ansible/kolla-venv/
+
+# Vagrant
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,82 +1,26 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# All Vagrant configuration is done below. The "2" in Vagrant.configure
-# configures the configuration version (we support older styles for
-# backwards compatibility). Please don't change it unless you know what
-# you're doing.
-Vagrant.configure("2") do |config|
-  # The most common configuration options are documented and commented below.
-  # For a complete reference, please see the online documentation at
-  # https://docs.vagrantup.com.
+Vagrant.configure('2') do |config|
+  config.vm.hostname = 'controller1'
 
-  # Every Vagrant development environment requires a box. You can search for
-  # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "centos/7"
+  config.vm.network 'private_network', ip: '192.168.33.3', auto_config: false
 
-  # Disable automatic box update checking. If you disable this, then
-  # boxes will only be checked for updates when the user runs
-  # `vagrant box outdated`. This is not recommended.
-  # config.vm.box_check_update = false
+  config.vm.box = 'stackhpc/centos-7'
 
-  # The default hostname is localhost, so set it to something a little more
-  # sensible.
-  config.vm.hostname = "controller1"
-
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
-  # config.vm.network "forwarded_port", guest: 80, host: 8080
-
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  config.vm.network "private_network", ip: "192.168.33.3", auto_config: false
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
-
-  # Share an additional folder to the guest VM. The first argument is
-  # the path on the host to the actual folder. The second argument is
-  # the path on the guest to mount the folder. And the optional third
-  # argument is a set of non-required options.
-
-  # NOTE: To make this work install vbguest plugin to install tools in VM:
-  #   vagrant plugin install vagrant-vbguest
-  config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
-
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
-  # Example for VirtualBox:
-  #
-  config.vm.provider "virtualbox" do |vb|
-    # Display the VirtualBox GUI when booting the machine
-    #vb.gui = true
-  
-    # Customize the amount of memory on the VM:
-    vb.memory = "4096"
+  config.vm.provider 'virtualbox' do |vb|
+    vb.memory = '4096'
+    vb.linked_clone = true
   end
-  #
-  # View the documentation for the provider you are using for more
-  # information on available options.
 
-  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
-  # such as FTP and Heroku are also available. See the documentation at
-  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
-  # config.push.define "atlas" do |push|
-  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
-  # end
+  config.vm.provider 'vmware_fusion' do |vmware|
+    vmware.vmx['memsize'] = '4096'
+    vmware.vmx['vhv.enable'] = 'TRUE'
+    vmware.linked_clone = true
+  end
 
-  # Enable provisioning with a shell script. Additional provisioners such as
-  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
-  # documentation for more information about their specific syntax and use.
-  #
-  # Set privileged: false to run as vagrant user.
-
-  # Disable selinux, then reboot to apply the change
-  config.vm.provision "shell", inline: <<-SHELL
-      echo "cat > /etc/selinux/config << EOF
+  config.vm.provision 'shell', inline: <<-SHELL
+    echo "cat > /etc/selinux/config << EOF
 SELINUX=disabled
 SELINUXTYPE=targeted
 EOF" | sudo -s
@@ -87,7 +31,7 @@ EOF" | sudo -s
   #   vagrant plugin install vagrant-reload
   config.vm.provision :reload
 
-  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+  config.vm.provision 'shell', privileged: false, inline: <<-SHELL
     cat << EOF | sudo tee /etc/sysconfig/network-scripts/ifcfg-eth1
 DEVICE=eth1
 USERCTL=no

--- a/dev/dev-hosts
+++ b/dev/dev-hosts
@@ -1,2 +1,5 @@
 [controllers]
-controller0 ansible_host=192.168.33.3
+controller1 ansible_host=192.168.33.3
+
+[container-image-builders]
+controller1 ansible_host=192.168.33.3

--- a/dev/dev-vagrant-network-allocation.yml
+++ b/dev/dev-vagrant-network-allocation.yml
@@ -1,2 +1,2 @@
 aio_ips:
-  controller0: 192.168.33.3
+  controller1: 192.168.33.3


### PR DESCRIPTION
This PR:

* Refactors the Vagrantfile somewhat and introduces support for VMware Fusion;
* In order to support HGFS for the above, it also switches the default Vagrant boxes to be ones hosted under the [StackHPC organisation](https://app.vagrantup.com/stackhpc/boxes/centos-7) on Vagrant Cloud.  These have been built with the relevant guest additions which are missing from the default CentOS images due to licensing shenanigans;
*  Adds the development VM to a `container-image-builders` group so that images can be built.