### PR TITLE
Always run dump-config.yml playbook in host configure

### DIFF
--- a/kayobe/ansible.py
+++ b/kayobe/ansible.py
@@ -169,7 +169,7 @@ def run_playbook(parsed_args, playbook, *args, **kwargs):
 
 
 def config_dump(parsed_args, host=None, hosts=None, var_name=None,
-                facts=None, extra_vars=None, verbose_level=None):
+                facts=None, extra_vars=None, tags=None, verbose_level=None):
     dump_dir = tempfile.mkdtemp()
     try:
         if not extra_vars:
@@ -184,7 +184,7 @@ def config_dump(parsed_args, host=None, hosts=None, var_name=None,
         # Don't use check mode for configuration dumps as we won't get any
         # results back.
         run_playbook(parsed_args, "ansible/dump-config.yml",
-                     extra_vars=extra_vars, quiet=True,
+                     extra_vars=extra_vars, tags=tags, quiet=True,
                      verbose_level=verbose_level, check=False)
         hostvars = {}
         for path in os.listdir(dump_dir):

--- a/kayobe/cli/commands.py
+++ b/kayobe/cli/commands.py
@@ -365,7 +365,10 @@ class SeedHostConfigure(KollaAnsibleMixin, KayobeAnsibleMixin, VaultMixin,
         self.app.LOG.debug("Configuring seed host OS")
 
         # Query some kayobe ansible variables.
-        hostvars = self.run_kayobe_config_dump(parsed_args, hosts="seed")
+        # Explicitly request the dump-config tag to ensure this play runs even
+        # if the user specified tags.
+        hostvars = self.run_kayobe_config_dump(parsed_args, hosts="seed",
+                                               tags="dump-config")
         if not hostvars:
             self.app.LOG.error("No hosts in the seed group")
             sys.exit(1)
@@ -649,7 +652,10 @@ class OvercloudHostConfigure(KollaAnsibleMixin, KayobeAnsibleMixin, VaultMixin,
         self.app.LOG.debug("Configuring overcloud host OS")
 
         # Query some kayobe ansible variables.
-        hostvars = self.run_kayobe_config_dump(parsed_args, hosts="overcloud")
+        # Explicitly request the dump-config tag to ensure this play runs even
+        # if the user specified tags.
+        hostvars = self.run_kayobe_config_dump(parsed_args, hosts="overcloud",
+                                               tags="dump-config")
         if not hostvars:
             self.app.LOG.error("No hosts in the overcloud group")
             sys.exit(1)

--- a/kayobe/tests/unit/cli/test_commands.py
+++ b/kayobe/tests/unit/cli/test_commands.py
@@ -152,7 +152,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(0, result)
 
         expected_calls = [
-            mock.call(mock.ANY, hosts="seed")
+            mock.call(mock.ANY, hosts="seed", tags="dump-config")
         ]
         self.assertEqual(expected_calls, mock_dump.call_args_list)
 
@@ -395,7 +395,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(0, result)
 
         expected_calls = [
-            mock.call(mock.ANY, hosts="overcloud")
+            mock.call(mock.ANY, hosts="overcloud", tags="dump-config")
         ]
         self.assertEqual(expected_calls, mock_dump.call_args_list)
 

--- a/kayobe/tests/unit/test_ansible.py
+++ b/kayobe/tests/unit/test_ansible.py
@@ -273,8 +273,8 @@ class TestCase(unittest.TestCase):
                                          extra_vars={
                                              "dump_path": dump_dir,
                                          },
-                                         quiet=True, verbose_level=None,
-                                         check=False)
+                                         quiet=True, tags=None,
+                                         verbose_level=None, check=False)
         mock_rmtree.assert_called_once_with(dump_dir)
         mock_listdir.assert_called_once_with(dump_dir)
         mock_read.assert_has_calls([


### PR DESCRIPTION
If the user specifies tags, the dump-config.yml playbook may not run,
which prevents us from looking up configuration.