### PR TITLE
Fix copy image ipa on seed

### DIFF
--- a/ansible/seed-ipa-build.yml
+++ b/ansible/seed-ipa-build.yml
@@ -35,18 +35,15 @@
             dest: "/etc/kolla/bifrost/{{ item }}"
             remote_src: True
           with_items: "{{ ipa_images }}"
-          notify:
-            - Copy Ironic Python Agent images into /httpboot
           become: True
-      when: ipa_build_images | bool
 
-  handlers:
-    - name: Copy Ironic Python Agent images into /httpboot
-      command: >
-        docker exec bifrost_deploy
-        bash -c 'source /bifrost/env-vars &&
-        ansible -vvvv target -i /bifrost/playbooks/inventory/target
-        -m copy
-        -a "src=/etc/bifrost/{{ item }} dest=/httpboot/{{ item }}"
-        -e "ansible_python_interpreter=/var/lib/kolla/venv/bin/python"'
-      with_items: "{{ ipa_images }}"
+        - name: Copy Ironic Python Agent images into /httpboot
+          command: >
+            docker exec bifrost_deploy
+            bash -c 'source /bifrost/env-vars &&
+            ansible -vvvv target -i /bifrost/playbooks/inventory/target
+            -m copy
+            -a "src=/etc/bifrost/{{ item }} dest=/httpboot/{{ item }}"
+            -e "ansible_python_interpreter=/var/lib/kolla/venv/bin/python"'
+          with_items: "{{ ipa_images }}"
+      when: ipa_build_images | bool


### PR DESCRIPTION
Hi
When we build the IPA images we must always copy them in bifrost otherwise they will not copy if they have already been built in the past. We meet this case when redeploying the seed, the images are not present in / httpboot /.
So we propose to systematically copy the images even if