### PR TITLE
Support configuring API interface via overcloud inventory file

### DIFF
--- a/ansible/kolla-ansible.yml
+++ b/ansible/kolla-ansible.yml
@@ -10,6 +10,19 @@
       set_fact:
         kolla_api_interface: "{{ internal_net_name | net_interface | replace('-', '_')  }}"
       when: internal_net_name in network_interfaces
+    - name: Validate overcloud host Kolla Ansible network configuration
+      fail:
+        msg: >
+          The Kolla Ansible variable {{ item.var_name }}
+          ({{ item.description }}) is invalid. Value:
+          "{{ hostvars[inventory_hostname][item.var_name] | default('<undefined>') }}".
+      when:
+        - item.required | bool
+        - hostvars[inventory_hostname][item.var_name] is not defined or not hostvars[inventory_hostname][item.var_name]
+      with_items:
+        - var_name: "kolla_api_interface"
+          description: "API network interface name"
+          required: True
 
 - name: Ensure Kolla Ansible is configured
   hosts: localhost
@@ -63,9 +76,6 @@
             - item.required | bool
             - hostvars[inventory_hostname][item.var_name] is not defined or not hostvars[inventory_hostname][item.var_name]
           with_items:
-            - var_name: "kolla_api_interface"
-              description: "API network interface name"
-              required: True
             - var_name: "kolla_provision_interface"
               description: "Bare metal provisioning network interface name"
               required: "{{ kolla_enable_ironic }}"

--- a/ansible/kolla-ansible.yml
+++ b/ansible/kolla-ansible.yml
@@ -1,4 +1,16 @@
 ---
+- name: Set interfaces for overcloud hosts
+  hosts: overcloud
+  tags:
+    - config
+    - kolla-ansible
+  gather_facts: False
+  tasks:
+    - name: Set API interface
+      set_fact:
+        kolla_api_interface: "{{ internal_net_name | net_interface | replace('-', '_')  }}"
+      when: internal_net_name in network_interfaces
+
 - name: Ensure Kolla Ansible is configured
   hosts: localhost
   tags:
@@ -35,7 +47,6 @@
         - name: Set facts containing the controller network interfaces
           set_fact:
             kolla_network_interface: "{{ internal_net_name | net_interface(controller_host) | replace('-', '_') }}"
-            kolla_api_interface: "{{ internal_net_name | net_interface(controller_host) | replace('-', '_') }}"
             kolla_storage_interface: "{{ storage_net_name | net_interface(controller_host) | replace('-', '_') }}"
             kolla_cluster_interface: "{{ storage_mgmt_net_name | net_interface(controller_host) | replace('-', '_') }}"
             kolla_provision_interface: "{{ provision_wl_net_name | net_interface(controller_host) | replace('-', '_') }}"

--- a/ansible/roles/kolla-ansible/defaults/main.yml
+++ b/ansible/roles/kolla-ansible/defaults/main.yml
@@ -69,6 +69,7 @@ kolla_overcloud_inventory_pass_through_host_vars:
   - "ansible_host"
   - "ansible_port"
   - "ansible_ssh_private_key_file"
+  - "kolla_api_interface"
 
 ###############################################################################
 # Kolla-ansible global configuration options.

--- a/ansible/roles/kolla-ansible/templates/globals.yml.j2
+++ b/ansible/roles/kolla-ansible/templates/globals.yml.j2
@@ -76,12 +76,17 @@ docker_registry_password: "{{ kolla_docker_registry_password }}"
 # Yet another way to workaround the naming problem is to create a bond for the
 # interface on all hosts and give the bond name here. Similar strategy can be
 # followed for other types of interfaces.
+#
+# NOTE: The following interfaces are configured via the inventory and are
+# therefore not set here:
+#
+# - api_interface
+
 network_interface: "{{ kolla_network_interface }}"
 
 # These can be adjusted for even more customization. The default is the same as
 # the 'network_interface'. These interfaces must contain an IPv4 address.
 kolla_external_vip_interface: "{{ kolla_external_vip_interface }}"
-api_interface: "{{ kolla_api_interface }}"
 storage_interface: "{{ kolla_storage_interface }}"
 cluster_interface: "{{ kolla_cluster_interface }}"
 dns_interface: "{{ kolla_dns_interface }}"

--- a/ansible/roles/kolla-ansible/templates/overcloud-top-level.j2
+++ b/ansible/roles/kolla-ansible/templates/overcloud-top-level.j2
@@ -17,7 +17,7 @@
 # These hostnames must be resolvable from your deployment host
 {% for host in groups.get(group, []) %}
 {% set host_hv=hostvars[host] %}
-{{ host }}{% for hv_name in kolla_overcloud_inventory_pass_through_host_vars %}{% if hv_name in host_hv %} {{ hv_name }}={{ host_hv[hv_name] }}{% endif %}{% endfor %}
+{{ host }}{% for hv_name in kolla_overcloud_inventory_pass_through_host_vars %}{% if hv_name in host_hv %} {{ hv_name | regex_replace('^kolla_(.*)$', '\1') }}={{ host_hv[hv_name] }}{% endif %}{% endfor %}
 
 {% endfor %}
 

--- a/ansible/roles/kolla-ansible/tests/test-defaults.yml
+++ b/ansible/roles/kolla-ansible/tests/test-defaults.yml
@@ -83,7 +83,6 @@
               docker_namespace: "fake-namespace"
               network_interface: "eth0"
               kolla_external_vip_interface: "eth1"
-              api_interface: "eth2"
               storage_interface: "eth3"
               cluster_interface: "eth4"
               dns_interface: "eth5"

--- a/ansible/roles/kolla-ansible/tests/test-extras.yml
+++ b/ansible/roles/kolla-ansible/tests/test-extras.yml
@@ -174,7 +174,6 @@
               docker_registry_password: "fake-password"
               network_interface: "eth0"
               kolla_external_vip_interface: "eth1"
-              api_interface: "eth2"
               storage_interface: "eth3"
               cluster_interface: "eth4"
               dns_interface: "eth5"


### PR DESCRIPTION
I've probably missed something. Once this is good, I can apply it to the other interfaces. It solves my issue with deploying grafana on a multinode host at least.