### PR TITLE
Support configuring Grafana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ ansible/roles/mrlesmithjr.manage-lvm/
 ansible/roles/MichaelRigart.interfaces/
 ansible/roles/stackhpc.drac/
 ansible/roles/stackhpc.drac-facts/
+ansible/roles/stackhpc.grafana-conf/
 ansible/roles/stackhpc.libvirt-host/
 ansible/roles/stackhpc.libvirt-vm/
 ansible/roles/stackhpc.os-flavors/

--- a/ansible/group_vars/all/grafana
+++ b/ansible/group_vars/all/grafana
@@ -1,0 +1,50 @@
+---
+###############################################################################
+# Grafana configuration.
+
+# Grafana local admin user name. If you are deploying Monasca Grafana this
+# should not conflict with an OpenStack user name.
+#grafana_local_admin_user_name:
+grafana_local_admin_user_name: "grafana_admin"
+
+# Path to git repo containing Grafana dashboards. Eg.
+# https://github.com/stackhpc/grafana-reference-dashboards.git
+#grafana_monitoring_node_dashboard_repo:
+grafana_monitoring_node_dashboard_repo:
+
+# Path to which Grafana dashboards will be cloned to a monitoring node
+#grafana_monitoring_node_dashboard_repo_path:
+grafana_monitoring_node_dashboard_repo_path: "/var/opt/grafana/"
+
+# The Grafana organisation for the control plane. Note that for Monasca
+# Grafana with domain support the format is:
+# organisation_name@openstack_domain
+#grafana_control_plane_organisation:
+grafana_control_plane_organisation: "control_plane"
+
+# A list of datasources to configure. See the stackhpc.grafana-conf role
+# for a list of supported datasources. Example:
+#
+# grafana_datasources:
+#   monasca_api:
+#     port: 8082
+#     host: monasca-api
+#   monasca_log_api:
+#     port: 5607
+#     host: monasca-log-api
+#   elasticsearch:
+#     port: 9200
+#     host: monasca-elasticsearch
+#     project_id: "some_id"
+#
+#grafana_datasources:
+grafana_datasources:
+
+# The path, relative to the grafana_monitoring_node_dashboard_repo_path
+# containing the dashboards. Eg. /prometheus/control_plane
+#grafana_monitoring_node_dashboard_path:
+grafana_monitoring_node_dashboard_path:
+
+###############################################################################
+# Dummy variable to allow Ansible to accept this file.
+workaround_ansible_issue_8743: yes

--- a/ansible/group_vars/all/grafana
+++ b/ansible/group_vars/all/grafana
@@ -25,8 +25,8 @@ grafana_monitoring_node_dashboard_repo_path:
 # organisation_name@openstack_domain
 grafana_control_plane_organisation: "control_plane"
 
-# A list of datasources to configure. See the stackhpc.grafana-conf role
-# for a list of supported datasources. Example:
+# A dict of datasources to configure. See the stackhpc.grafana-conf role
+# for all supported datasources. Example:
 #
 # grafana_datasources:
 #   monasca_api:

--- a/ansible/group_vars/all/grafana
+++ b/ansible/group_vars/all/grafana
@@ -10,8 +10,15 @@ grafana_local_admin_user_name: "grafana_admin"
 # https://github.com/stackhpc/grafana-reference-dashboards.git
 grafana_monitoring_node_dashboard_repo:
 
+# Dashboard repo version. Optional, defaults to 'HEAD'.
+grafana_monitoring_node_dashboard_repo_version:
+
 # Path to which Grafana dashboards will be cloned to a monitoring node
-grafana_monitoring_node_dashboard_repo_path: "{{ source_checkout_path ~ '/grafana' }}"
+grafana_monitoring_node_dashboard_repo_checkout_path: "{{ source_checkout_path ~ '/grafana-dashboards' }}"
+
+# The path, relative to the grafana_monitoring_node_dashboard_repo_checkout_path
+# containing the dashboards. Eg. /prometheus/control_plane
+grafana_monitoring_node_dashboard_repo_path:
 
 # The Grafana organisation for the control plane. Note that for Monasca
 # Grafana with domain support the format is:
@@ -34,9 +41,5 @@ grafana_control_plane_organisation: "control_plane"
 #     project_id: "some_id"
 #
 grafana_datasources: {}
-
-# The path, relative to the grafana_monitoring_node_dashboard_repo_path
-# containing the dashboards. Eg. /prometheus/control_plane
-grafana_monitoring_node_dashboard_path:
 
 ###############################################################################

--- a/ansible/group_vars/all/grafana
+++ b/ansible/group_vars/all/grafana
@@ -4,22 +4,18 @@
 
 # Grafana local admin user name. If you are deploying Monasca Grafana this
 # should not conflict with an OpenStack user name.
-#grafana_local_admin_user_name:
 grafana_local_admin_user_name: "grafana_admin"
 
 # Path to git repo containing Grafana dashboards. Eg.
 # https://github.com/stackhpc/grafana-reference-dashboards.git
-#grafana_monitoring_node_dashboard_repo:
 grafana_monitoring_node_dashboard_repo:
 
 # Path to which Grafana dashboards will be cloned to a monitoring node
-#grafana_monitoring_node_dashboard_repo_path:
-grafana_monitoring_node_dashboard_repo_path: "/var/opt/grafana/"
+grafana_monitoring_node_dashboard_repo_path: "{{ source_checkout_path ~ '/grafana' }}"
 
 # The Grafana organisation for the control plane. Note that for Monasca
 # Grafana with domain support the format is:
 # organisation_name@openstack_domain
-#grafana_control_plane_organisation:
 grafana_control_plane_organisation: "control_plane"
 
 # A list of datasources to configure. See the stackhpc.grafana-conf role
@@ -37,14 +33,10 @@ grafana_control_plane_organisation: "control_plane"
 #     host: monasca-elasticsearch
 #     project_id: "some_id"
 #
-#grafana_datasources:
-grafana_datasources:
+grafana_datasources: {}
 
 # The path, relative to the grafana_monitoring_node_dashboard_repo_path
 # containing the dashboards. Eg. /prometheus/control_plane
-#grafana_monitoring_node_dashboard_path:
 grafana_monitoring_node_dashboard_path:
 
 ###############################################################################
-# Dummy variable to allow Ansible to accept this file.
-workaround_ansible_issue_8743: yes

--- a/ansible/group_vars/all/grafana
+++ b/ansible/group_vars/all/grafana
@@ -4,7 +4,7 @@
 
 # Grafana local admin user name. If you are deploying Monasca Grafana this
 # should not conflict with an OpenStack user name.
-grafana_local_admin_user_name: "grafana_admin"
+grafana_local_admin_user_name: "admin"
 
 # Path to git repo containing Grafana dashboards. Eg.
 # https://github.com/stackhpc/grafana-reference-dashboards.git

--- a/ansible/overcloud-grafana-configure.yml
+++ b/ansible/overcloud-grafana-configure.yml
@@ -1,0 +1,44 @@
+---
+- name: Check whether Grafana is enabled
+  hosts: overcloud
+  tags:
+    - grafana
+  tasks:
+    - name: Create monitoring group with grafana enabled
+      group_by:
+        key: "monitoring_with_grafana_enabled_{{ kolla_enable_grafana | bool }}"
+
+- name: Configure control plane monitoring for Grafana
+  # Only required to run on a single host.
+  hosts: monitoring_with_grafana_enabled_True[0]
+  gather_facts: False
+  tags:
+    - grafana
+  pre_tasks:
+    - name: Set fact for the VIP address
+      set_fact:
+        kolla_internal_vip_address: "{{ internal_net_name | net_vip_address }}"
+      when: kolla_enable_haproxy | bool
+
+    - name: Set fact for the VIP address
+      set_fact:
+        kolla_internal_vip_address: "{{ internal_net_name | net_ip(network_host) }}"
+      when: not kolla_enable_haproxy | bool
+
+    - name: Clone dashboards
+      git:
+        repo: "{{ grafana_monitoring_node_dashboard_repo }}"
+        dest: "{{ grafana_monitoring_node_dashboard_repo_path }}"
+      when: grafana_monitoring_node_dashboard_repo | bool
+      become: True
+
+    - name: Include Kolla passwords for Grafana local admin account credentials
+      include_vars: "{{ kayobe_config_path }}/kolla/passwords.yml"
+  roles:
+    - role: stackhpc.grafana-conf
+      grafana_conf_organisation: "{{ grafana_control_plane_organisation }}"
+      grafana_conf_grafana_admin_user: "{{ grafana_local_admin_user_name }}"
+      grafana_conf_grafana_admin_pass: "{{ grafana_admin_password }}"
+      grafana_conf_grafana_url: "http://{{ kolla_internal_vip_address }}:3000"
+      grafana_conf_grafana_datasources: "{{ grafana_datasources }}"
+      grafana_conf_grafana_dashboards: "{{ grafana_monitoring_node_dashboard_repo_path }}{{ grafana_monitoring_node_dashboard_path }}"

--- a/ansible/overcloud-grafana-configure.yml
+++ b/ansible/overcloud-grafana-configure.yml
@@ -22,7 +22,7 @@
 
     - name: Set fact for the VIP address
       set_fact:
-        kolla_internal_vip_address: "{{ internal_net_name | net_ip(network_host) }}"
+        kolla_internal_vip_address: "{{ internal_net_name | net_ip }}"
       when: not kolla_enable_haproxy | bool
 
     - name: Include Kolla passwords for Grafana local admin account credentials

--- a/ansible/overcloud-grafana-configure.yml
+++ b/ansible/overcloud-grafana-configure.yml
@@ -25,13 +25,6 @@
         kolla_internal_vip_address: "{{ internal_net_name | net_ip(network_host) }}"
       when: not kolla_enable_haproxy | bool
 
-    - name: Clone dashboards
-      git:
-        repo: "{{ grafana_monitoring_node_dashboard_repo }}"
-        dest: "{{ grafana_monitoring_node_dashboard_repo_path }}"
-      when: grafana_monitoring_node_dashboard_repo | bool
-      become: True
-
     - name: Include Kolla passwords for Grafana local admin account credentials
       include_vars: "{{ kayobe_config_path }}/kolla/passwords.yml"
   roles:
@@ -39,6 +32,9 @@
       grafana_conf_organisation: "{{ grafana_control_plane_organisation }}"
       grafana_conf_grafana_admin_user: "{{ grafana_local_admin_user_name }}"
       grafana_conf_grafana_admin_pass: "{{ grafana_admin_password }}"
+      grafana_conf_grafana_dashboard_repo:
+        path: "{{ grafana_monitoring_node_dashboard_repo }}"
+        checkout_path: "{{ grafana_monitoring_node_dashboard_repo_path }}"
+        relative_path: "{{ grafana_monitoring_node_dashboard_path }}"
       grafana_conf_grafana_url: "http://{{ kolla_internal_vip_address }}:3000"
       grafana_conf_grafana_datasources: "{{ grafana_datasources }}"
-      grafana_conf_grafana_dashboards: "{{ grafana_monitoring_node_dashboard_repo_path }}{{ grafana_monitoring_node_dashboard_path }}"

--- a/ansible/overcloud-grafana-configure.yml
+++ b/ansible/overcloud-grafana-configure.yml
@@ -33,8 +33,9 @@
       grafana_conf_grafana_admin_user: "{{ grafana_local_admin_user_name }}"
       grafana_conf_grafana_admin_pass: "{{ grafana_admin_password }}"
       grafana_conf_grafana_dashboard_repo:
-        path: "{{ grafana_monitoring_node_dashboard_repo }}"
-        checkout_path: "{{ grafana_monitoring_node_dashboard_repo_path }}"
-        relative_path: "{{ grafana_monitoring_node_dashboard_path }}"
+        repo: "{{ grafana_monitoring_node_dashboard_repo }}"
+        version: "{{ grafana_monitoring_node_dashboard_repo_version }}"
+        checkout_path: "{{ grafana_monitoring_node_dashboard_repo_checkout_path }}"
+        relative_path: "{{ grafana_monitoring_node_dashboard_repo_path }}"
       grafana_conf_grafana_url: "http://{{ kolla_internal_vip_address }}:3000"
       grafana_conf_grafana_datasources: "{{ grafana_datasources }}"

--- a/ansible/roles/kolla-openstack/templates/grafana.ini.j2
+++ b/ansible/roles/kolla-openstack/templates/grafana.ini.j2
@@ -1,5 +1,14 @@
 # {{ ansible_managed }}
 
+[security]
+; If an OpenStack user with the same name as the admin user logs into
+; Grafana it overwrites user data in the Grafana database, breaking
+; the local admin account, and preventing admin API calls to Grafana. To
+; reduce the chance of this happening we rename the local admin user here.
+; Note that this only affects the Monasca fork of Grafana.
+;admin_user = admin
+admin_user = {{ grafana_local_admin_user_name }}
+
 {% if kolla_extra_grafana %}
 #######################
 # Extra configuration

--- a/doc/source/deployment.rst
+++ b/doc/source/deployment.rst
@@ -379,3 +379,4 @@ This will perform the following tasks:
 - Register Ironic Python Agent (IPA) images with glance
 - Register introspection rules with ironic inspector
 - Register a provisioning network and subnet with neutron
+- Configure Grafana organisations, dashboards and datasources

--- a/etc/kayobe/grafana.yml
+++ b/etc/kayobe/grafana.yml
@@ -10,7 +10,14 @@
 # https://github.com/stackhpc/grafana-reference-dashboards.git
 #grafana_monitoring_node_dashboard_repo:
 
+# Dashboard repo version. Optional, defaults to 'HEAD'.
+#grafana_monitoring_node_dashboard_repo_version:
+
 # Path to which Grafana dashboards will be cloned to a monitoring node
+#grafana_monitoring_node_dashboard_repo_checkout_path:
+
+# The path, relative to the grafana_monitoring_node_dashboard_repo_checkout_path
+# containing the dashboards. Eg. /prometheus/control_plane
 #grafana_monitoring_node_dashboard_repo_path:
 
 # The Grafana organisation for the control plane. Note that for Monasca
@@ -18,8 +25,8 @@
 # organisation_name@openstack_domain
 #grafana_control_plane_organisation:
 
-# A list of datasources to configure. See the stackhpc.grafana-conf role
-# for a list of supported datasources. Example:
+# A dict of datasources to configure. See the stackhpc.grafana-conf role
+# for all supported datasources. Example:
 #
 # grafana_datasources:
 #   monasca_api:
@@ -34,10 +41,6 @@
 #     project_id: "some_id"
 #
 #grafana_datasources:
-
-# The path, relative to the grafana_monitoring_node_dashboard_repo_path
-# containing the dashboards. Eg. /prometheus/control_plane
-#grafana_monitoring_node_dashboard_path:
 
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.

--- a/etc/kayobe/grafana.yml
+++ b/etc/kayobe/grafana.yml
@@ -1,0 +1,44 @@
+---
+###############################################################################
+# Grafana configuration.
+
+# Grafana local admin user name. If you are deploying Monasca Grafana this
+# should not conflict with an OpenStack user name.
+#grafana_local_admin_user_name:
+
+# Path to git repo containing Grafana dashboards. Eg.
+# https://github.com/stackhpc/grafana-reference-dashboards.git
+#grafana_monitoring_node_dashboard_repo:
+
+# Path to which Grafana dashboards will be cloned to a monitoring node
+#grafana_monitoring_node_dashboard_repo_path:
+
+# The Grafana organisation for the control plane. Note that for Monasca
+# Grafana with domain support the format is:
+# organisation_name@openstack_domain
+#grafana_control_plane_organisation:
+
+# A list of datasources to configure. See the stackhpc.grafana-conf role
+# for a list of supported datasources. Example:
+#
+# grafana_datasources:
+#   monasca_api:
+#     port: 8082
+#     host: monasca-api
+#   monasca_log_api:
+#     port: 5607
+#     host: monasca-log-api
+#   elasticsearch:
+#     port: 9200
+#     host: monasca-elasticsearch
+#     project_id: "some_id"
+#
+#grafana_datasources:
+
+# The path, relative to the grafana_monitoring_node_dashboard_repo_path
+# containing the dashboards. Eg. /prometheus/control_plane
+#grafana_monitoring_node_dashboard_path:
+
+###############################################################################
+# Dummy variable to allow Ansible to accept this file.
+workaround_ansible_issue_8743: yes

--- a/kayobe/cli/commands.py
+++ b/kayobe/cli/commands.py
@@ -1087,6 +1087,7 @@ class OvercloudPostConfigure(KayobeAnsibleMixin, VaultMixin, Command):
     * Register ironic inspector introspection rules with the overcloud
       inspector service.
     * Register a provisioning network with glance.
+    * Configure Grafana for control plane.
     """
 
     def take_action(self, parsed_args):
@@ -1094,7 +1095,7 @@ class OvercloudPostConfigure(KayobeAnsibleMixin, VaultMixin, Command):
         playbooks = _build_playbook_list(
             "overcloud-ipa-images", "overcloud-introspection-rules",
             "overcloud-introspection-rules-dell-lldp-workaround",
-            "provision-net")
+            "provision-net", "overcloud-grafana-configure")
         self.run_kayobe_playbooks(parsed_args, playbooks)
 
 

--- a/kayobe/tests/unit/cli/test_commands.py
+++ b/kayobe/tests/unit/cli/test_commands.py
@@ -674,6 +674,30 @@ class TestCase(unittest.TestCase):
 
     @mock.patch.object(commands.KayobeAnsibleMixin,
                        "run_kayobe_playbooks")
+    def test_overcloud_post_configure(self, mock_run):
+        command = commands.OvercloudPostConfigure(TestApp(), [])
+        parser = command.get_parser("test")
+        parsed_args = parser.parse_args([])
+
+        result = command.run(parsed_args)
+        self.assertEqual(0, result)
+
+        expected_calls = [
+            mock.call(
+                mock.ANY,
+                [
+                    'ansible/overcloud-ipa-images.yml',
+                    'ansible/overcloud-introspection-rules.yml',
+                    'ansible/overcloud-introspection-rules-dell-lldp-workaround.yml',
+                    'ansible/provision-net.yml',
+                    'ansible/overcloud-grafana-configure.yml'
+                ],
+            ),
+        ]
+        self.assertEqual(expected_calls, mock_run.call_args_list)
+
+    @mock.patch.object(commands.KayobeAnsibleMixin,
+                       "run_kayobe_playbooks")
     def test_baremetal_compute_inspect(self, mock_run):
         command = commands.BaremetalComputeInspect(TestApp(), [])
         parser = command.get_parser("test")

--- a/kayobe/tests/unit/cli/test_commands.py
+++ b/kayobe/tests/unit/cli/test_commands.py
@@ -688,7 +688,7 @@ class TestCase(unittest.TestCase):
                 [
                     'ansible/overcloud-ipa-images.yml',
                     'ansible/overcloud-introspection-rules.yml',
-                    'ansible/overcloud-introspection-rules-dell-lldp-workaround.yml',
+                    'ansible/overcloud-introspection-rules-dell-lldp-workaround.yml',  # noqa
                     'ansible/provision-net.yml',
                     'ansible/overcloud-grafana-configure.yml'
                 ],

--- a/requirements.yml
+++ b/requirements.yml
@@ -10,6 +10,7 @@
   name: singleplatform-eng.users
 - src: stackhpc.drac
 - src: stackhpc.drac-facts
+- src: stackhpc.grafana-conf
 - src: stackhpc.libvirt-host
 - src: stackhpc.libvirt-vm
 - src: stackhpc.os-flavors


### PR DESCRIPTION
This add supports for running the stackhpc.grafana-conf Ansible
Galaxy role against a monitoring server to configure Grafana
post deployment. This includes:

* Creating an organisation
* Configuring dashboards for the organisation from a git repo
* Configuring datasources for the organisation