### PR TITLE
Remove pip install sphinx from pep8 tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,11 +23,7 @@ commands =
   flake8 {posargs} kayobe
   # Check the *.rst files
   # We use a thin wrapper around doc8 currently, which has support for sphinx
-  # directives. We install sphinx 1.5.x because versions prior to this
-  # (installed due to upper constraints) automatically import all
-  # sphinx.directive.* modules when any one of those modules is imported, and
-  # importing sphinx.directive.other breaks docutils parsing.
-  pip install -U sphinx<1.6
+  # directives.
   {toxinidir}/tools/sphinx8 README.rst CONTRIBUTING.rst doc/source --ignore D001
 
 [testenv:venv]


### PR DESCRIPTION
This was required when upper constraints restricted sphinx to < 1.5. UC now has an
appropriate version of sphinx.