### PR TITLE
Support copying TLS certificates into place

### DIFF
--- a/ansible/group_vars/all/kolla
+++ b/ansible/group_vars/all/kolla
@@ -272,9 +272,6 @@ kolla_ansible_vault_password: "{{ lookup('env', 'KAYOBE_VAULT_PASSWORD') | defau
 # Whether TLS is enabled for the external API endpoints.
 kolla_enable_tls_external: "no"
 
-# Path to external API certificate.
-kolla_external_fqdn_cert:
-
 # Whether debug logging is enabled.
 kolla_openstack_logging_debug: "False"
 
@@ -335,3 +332,14 @@ kolla_ansible_default_custom_passwords:
 # Dictionary containing custom passwords to add or override in the Kolla
 # passwords file.
 kolla_ansible_custom_passwords: "{{ kolla_ansible_default_custom_passwords }}"
+
+###############################################################################
+# TLS certificate bundle management
+
+# Optionally copy a TLS certificate bundle into place.
+#
+# When enabled, this will copy the contents of kolla_tls_cert into place for
+# use by HAProxy
+#
+# Note that this should be formatted as a literal style block scalar.
+kolla_tls_cert:

--- a/ansible/group_vars/all/overcloud
+++ b/ansible/group_vars/all/overcloud
@@ -17,7 +17,7 @@ overcloud_groups: >
 overcloud_group_hosts_map: {}
 
 # To prevent some network issues you can choose to disable cloud-init
-disable_cloud_init: False 
+disable_cloud_init: False
 
 ###############################################################################
 # Overcloud host image configuration.

--- a/ansible/kolla-ansible.yml
+++ b/ansible/kolla-ansible.yml
@@ -221,4 +221,5 @@
 
   roles:
     - role: kolla-ansible
+      kolla_external_fqdn_cert: "{{ kolla_config_path }}/certificates/haproxy.pem"
       kolla_ansible_passwords_path: "{{ kayobe_config_path }}/kolla/passwords.yml"

--- a/ansible/roles/kolla-ansible/defaults/main.yml
+++ b/ansible/roles/kolla-ansible/defaults/main.yml
@@ -246,3 +246,10 @@ kolla_extra_globals:
 # Dictionary containing custom passwords to add or override in the Kolla
 # passwords file.
 kolla_ansible_custom_passwords: {}
+
+###############################################################################
+# TLS certificate bundle management
+
+# When set, this will copy the contents of this variable into place for 
+# use by HAProxy.
+kolla_tls_cert:

--- a/ansible/roles/kolla-ansible/tasks/config.yml
+++ b/ansible/roles/kolla-ansible/tasks/config.yml
@@ -48,3 +48,15 @@
     src: "{{ kolla_ansible_passwords_path }}"
     dest: "{{ kolla_config_path }}/passwords.yml"
     remote_src: True
+
+- name: Ensure the HAProxy TLS certificate bundle is copied into place
+  block:
+    - file:
+        path: "{{ kolla_external_fqdn_cert | dirname }}"
+        state: directory
+        recurse: yes
+    - copy:
+        content: "{{ kolla_tls_cert }}"
+        dest: "{{ kolla_external_fqdn_cert }}"
+  when:
+    - kolla_tls_cert is not none

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -138,9 +138,6 @@
 # Whether TLS is enabled for the external API endpoints.
 #kolla_enable_tls_external:
 
-# Path to external API certificate.
-#kolla_external_fqdn_cert:
-
 # Whether debug logging is enabled.
 #kolla_openstack_logging_debug:
 
@@ -221,6 +218,17 @@
 # Dictionary containing custom passwords to add or override in the Kolla
 # passwords file.
 #kolla_ansible_custom_passwords:
+
+###############################################################################
+# TLS certificate bundle management
+
+# Optionally copy a TLS certificate bundle into place.
+#
+# When enabled, this will copy the contents of kolla_tls_cert into place for 
+# use by HAproxy.
+#
+# Note that this should be formatted as a literal style block scalar.
+#kolla_tls_cert:
 
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.


### PR DESCRIPTION
This commit handles deployment of TLS certificates on control nodes for use by HAProxy, when `kolla_enable_tls_external` is True and a new variable, `kolla_tls_cert`, is populated with the contents of the certificate file.