### PR TITLE
Fix use of tags with overcloud post configure

### DIFF
--- a/ansible/overcloud-introspection-rules-dell-lldp-workaround.yml
+++ b/ansible/overcloud-introspection-rules-dell-lldp-workaround.yml
@@ -16,10 +16,10 @@
   tasks:
     - name: Create controllers group with ironic enabled
       group_by:
-        key: "controllers_with_ironic_enabled_{{ kolla_enable_ironic | bool }}"
+        key: "controllers_for_introspection_rules_dell_lldp_workaround_{{ kolla_enable_ironic | bool }}"
 
 - name: Group controller hosts in systems requiring the workaround
-  hosts: controllers_with_ironic_enabled_True
+  hosts: controllers_for_introspection_rules_dell_lldp_workaround_True
   gather_facts: False
   tags:
     - introspection-rules

--- a/ansible/overcloud-introspection-rules.yml
+++ b/ansible/overcloud-introspection-rules.yml
@@ -6,11 +6,11 @@
   tasks:
     - name: Create controllers group with ironic enabled
       group_by:
-        key: "controllers_with_ironic_enabled_{{ kolla_enable_ironic | bool }}"
+        key: "controllers_for_introspection_rules_{{ kolla_enable_ironic | bool }}"
 
 - name: Ensure introspection rules are registered in Ironic Inspector
   # Only required to run on a single host.
-  hosts: controllers_with_ironic_enabled_True[0]
+  hosts: controllers_for_introspection_rules_True[0]
   gather_facts: False
   tags:
     - introspection-rules

--- a/ansible/overcloud-ipa-build.yml
+++ b/ansible/overcloud-ipa-build.yml
@@ -11,10 +11,10 @@
   tasks:
     - name: Create controllers group with ironic enabled
       group_by:
-        key: "controllers_with_ironic_enabled_{{ kolla_enable_ironic | bool }}"
+        key: "controllers_for_ipa_build_{{ kolla_enable_ironic | bool }}"
 
 - name: Ensure Ironic Python Agent images are built and installed
-  hosts: controllers_with_ironic_enabled_True[0]
+  hosts: controllers_for_ipa_build_True[0]
   gather_facts: False
   tags:
     - ipa-build

--- a/ansible/overcloud-ipa-images.yml
+++ b/ansible/overcloud-ipa-images.yml
@@ -6,10 +6,10 @@
   tasks:
     - name: Create controllers group with ironic enabled
       group_by:
-        key: "controllers_with_ironic_enabled_{{ kolla_enable_ironic | bool }}"
+        key: "controllers_for_ipa_images_{{ kolla_enable_ironic | bool }}"
 
 - name: Ensure Ironic Python Agent (IPA) images are downloaded and registered
-  hosts: controllers_with_ironic_enabled_True[0]
+  hosts: controllers_for_ipa_images_True[0]
   gather_facts: False
   tags:
     - ipa-images

--- a/ansible/provision-net.yml
+++ b/ansible/provision-net.yml
@@ -6,11 +6,11 @@
   tasks:
     - name: Create controllers group with ironic enabled
       group_by:
-        key: "controllers_with_ironic_enabled_{{ kolla_enable_ironic | bool }}"
+        key: "controllers_for_provision_net_{{ kolla_enable_ironic | bool }}"
 
 - name: Ensure provisioning network and subnet are registered in neutron
   # Only required to run on a single host.
-  hosts: controllers_with_ironic_enabled_True[0]
+  hosts: controllers_for_provision_net_True[0]
   gather_facts: False
   tags:
     - provision-net


### PR DESCRIPTION
When specifying tags with 'kayobe overcloud post configure --tags <tags>', the
expected plays typically do not run. This seems to be due to an ansible bug,
where if a dynamically created group is referenced before creation, it will
remain empty. See https://github.com/ansible/ansible/issues/20360.

This change works around this issue by modifying the name of the dynamic groups
used in the post configure playbooks to be unique to each playbook.

Fixes: #138