### PR TITLE
Add preliminary support for Monasca APIs

### DIFF
--- a/ansible/roles/kolla-ansible/templates/overcloud-components.j2
+++ b/ansible/roles/kolla-ansible/templates/overcloud-components.j2
@@ -121,6 +121,9 @@ control
 [heat:children]
 control
 
+[monasca:children]
+monitoring
+
 [murano:children]
 control
 

--- a/ansible/roles/kolla-ansible/templates/overcloud-services.j2
+++ b/ansible/roles/kolla-ansible/templates/overcloud-services.j2
@@ -172,6 +172,13 @@ heat
 [heat-engine:children]
 heat
 
+# Monasca
+[monasca-api:children]
+monasca
+
+[monasca-log-api:children]
+monasca
+
 # Murano
 [murano-api:children]
 murano


### PR DESCRIPTION
If one deploys the Monasca APIs using the in-review patches
for upstream kolla-ansible, the Monasca API sections do not
exist in the Kayobe overcloud inventory causing HAProxy
configuration via Kayobe to fail.

TrivialFix
Change-Id: I4ba4c3e9136219bb48ec7a14bb78a7024850c7e6