### PR TITLE
Adds a separate admin network

### DIFF
--- a/ansible/group_vars/all/compute
+++ b/ansible/group_vars/all/compute
@@ -16,7 +16,7 @@ compute_network_interfaces: >
 
 # List of default networks to which compute nodes are attached.
 compute_default_network_interfaces: >
-  {{ ([provision_oc_net_name,
+  {{ ([admin_oc_net_name,
        internal_net_name,
        storage_net_name] +
       (external_net_names if kolla_enable_neutron_provider_networks | bool else [])) | unique | list }}

--- a/ansible/group_vars/all/controllers
+++ b/ansible/group_vars/all/controllers
@@ -18,7 +18,7 @@ controller_network_interfaces: >
 
 # List of default networks to which controller nodes are attached.
 controller_default_network_interfaces: >
-  {{ [provision_oc_net_name,
+  {{ [admin_oc_net_name,
       oob_wl_net_name,
       provision_wl_net_name,
       inspection_net_name,

--- a/ansible/group_vars/all/monitoring
+++ b/ansible/group_vars/all/monitoring
@@ -18,7 +18,7 @@ monitoring_network_interfaces: >
 
 # List of default networks to which monitoring nodes are attached.
 monitoring_default_network_interfaces: >
-  {{ [provision_oc_net_name,
+  {{ [admin_oc_net_name,
       internal_net_name,
       public_net_name] | unique | list }}
 

--- a/ansible/group_vars/all/network
+++ b/ansible/group_vars/all/network
@@ -2,6 +2,9 @@
 ###############################################################################
 # Network role to network name mappings.
 
+# Name of the network used for admin access to the overcloud
+admin_oc_net_name: "{{ provision_oc_net_name }}"
+
 # Name of the network used by the overcloud hosts to manage the bare metal
 # compute hosts via their out-of-band management controllers.
 oob_oc_net_name: 'oob_oc_net'

--- a/ansible/group_vars/all/seed
+++ b/ansible/group_vars/all/seed
@@ -16,7 +16,8 @@ seed_network_interfaces: >
 
 # List of default networks to which seed nodes are attached.
 seed_default_network_interfaces: >
-  {{ [oob_oc_net_name,
+  {{ [admin_oc_net_name,
+      oob_oc_net_name,
       provision_oc_net_name] | unique | list }}
 
 # List of extra networks to which seed nodes are attached.

--- a/ansible/group_vars/all/storage
+++ b/ansible/group_vars/all/storage
@@ -16,7 +16,7 @@ storage_network_interfaces: >
 
 # List of default networks to which storage nodes are attached.
 storage_default_network_interfaces: >
-  {{ [provision_oc_net_name,
+  {{ [admin_oc_net_name,
       internal_net_name,
       storage_mgmt_net_name,
       storage_net_name] | unique | list }}

--- a/ansible/group_vars/overcloud/ansible-host
+++ b/ansible/group_vars/overcloud/ansible-host
@@ -1,3 +1,3 @@
 ---
 # Host/IP with which to access the overcloud nodes via SSH.
-ansible_host: "{{ provision_oc_net_name | net_ip }}"
+ansible_host: "{{ admin_oc_net_name | net_ip }}"

--- a/ansible/group_vars/seed-hypervisor/ansible-host
+++ b/ansible/group_vars/seed-hypervisor/ansible-host
@@ -1,3 +1,3 @@
 ---
 # Host/IP with which to access the seed hypervisor via SSH.
-ansible_host: "{{ provision_oc_net_name | net_ip }}"
+ansible_host: "{{ admin_oc_net_name | net_ip }}"

--- a/ansible/group_vars/seed/ansible-host
+++ b/ansible/group_vars/seed/ansible-host
@@ -1,3 +1,3 @@
 ---
 # Host/IP with which to access the seed via SSH.
-ansible_host: "{{ provision_oc_net_name | net_ip }}"
+ansible_host: "{{ admin_oc_net_name | net_ip }}"

--- a/ansible/kolla-bifrost-hostvars.yml
+++ b/ansible/kolla-bifrost-hostvars.yml
@@ -30,17 +30,17 @@
   vars:
     seed_host: "{{ groups['seed'][0] }}"
     bifrost_hostvars:
-      # Also supports vlan_id and network_mtu.
       addressing_mode: static
       ipv4_interface_mac: "{% raw %}{{ extra.pxe_interface_mac | default }}{% endraw %}"
-      ipv4_address: "{{ provision_oc_net_name | net_ip }}"
-      ipv4_subnet_mask: "{{ provision_oc_net_name | net_cidr | ipaddr('netmask') }}"
-      # If the provisioning network does not have a gateway defined, use the
+      ipv4_address: "{{ admin_oc_net_name | net_ip }}"
+      ipv4_subnet_mask: "{{ admin_oc_net_name | net_cidr | ipaddr('netmask') }}"
+      # If the admin network does not have a gateway defined, use the
       # seed as a gateway to allow external access until other networks have
       # been configured.
-      ipv4_gateway: "{{ provision_oc_net_name | net_gateway or provision_oc_net_name | net_ip(seed_host) }}"
+      ipv4_gateway: "{{ admin_oc_net_name | net_gateway or admin_oc_net_name | net_ip(seed_host) }}"
       ipv4_nameserver: "{{ resolv_nameservers }}"
-      network_mtu: "{{ provision_oc_net_name | net_mtu or '1500' }}"
+      network_mtu: "{{ admin_oc_net_name | net_mtu or '1500' }}"
+      vlan_id: "{{ '' if admin_oc_net_name == provision_oc_net_name else (admin_oc_net_name | net_vlan) }}"
   tasks:
     - name: Ensure the Bifrost host variable files exist
       copy:

--- a/ansible/overcloud-etc-hosts-fixup.yml
+++ b/ansible/overcloud-etc-hosts-fixup.yml
@@ -1,29 +1,29 @@
 ---
 # For some currently unknown reason, overcloud hosts end up with multiple
-# entries in /etc/hosts that map their own hostname to their provisioning
+# entries in /etc/hosts that map their own hostname to their admin
 # network IP address, in addition to one that maps their own hostname to their
 # internal network IP address. This causes RabbitMQ upgrades to fail, as
 # RabbitMQ expects the system's hostname to resolve to the IP address on
 # which it is listening. As a workaround, we remove the stale entries from
 # /etc/hosts.  See https://github.com/stackhpc/kayobe/issues/14.
 
-- name: Ensure overcloud hosts' /etc/hosts does not contain provisioning network IP
+- name: Ensure overcloud hosts' /etc/hosts does not contain admin network IP
   hosts: overcloud
   tags:
     - etc-hosts-fixup
   tasks:
-    - name: Ensure overcloud hosts' /etc/hosts does not contain provisioning network or loopback IPs
+    - name: Ensure overcloud hosts' /etc/hosts does not contain admin network or loopback IPs
       lineinfile:
         dest: /etc/hosts
         regexp: "^{{ item }}[ \t]*{{ inventory_hostname }}"
         state: absent
       with_items:
         - "127.0.0.1"
-        - "{{ provision_oc_net_name | net_ip }}"
-      when: provision_oc_net_name | net_ip != None
+        - "{{ admin_oc_net_name | net_ip }}"
+      when: admin_oc_net_name | net_ip != None
       become: True
 
-- name: Ensure rabbitmq containers' /etc/hosts does not contain provisioning network or loopback IPs
+- name: Ensure rabbitmq containers' /etc/hosts does not contain admin network or loopback IPs
   hosts: overcloud
   tags:
     - etc-hosts-fixup
@@ -40,7 +40,7 @@
           with_items: "{{ rabbitmq_containers }}"
           register: ps_result
 
-        - name: Ensure rabbitmq containers' /etc/hosts does not contain provisioning network or loopback IPs
+        - name: Ensure rabbitmq containers' /etc/hosts does not contain admin network or loopback IPs
           command: >
             docker exec -u root {{ item.0.item }}
             bash -c
@@ -55,7 +55,7 @@
           with_nested:
             - "{{ ps_result.results }}"
             - - "127.0.0.1"
-              - "{{ provision_oc_net_name | net_ip }}"
+              - "{{ admin_oc_net_name | net_ip }}"
           when: item.0.rc == 0
           register: sed_result
-      when: provision_oc_net_name | net_ip != None
+      when: admin_oc_net_name | net_ip != None

--- a/doc/source/configuration/network.rst
+++ b/doc/source/configuration/network.rst
@@ -398,6 +398,9 @@ In order to provide flexibility in the system's network topology, Kayobe maps
 the named networks to logical network roles.  A single named network may
 perform multiple roles, or even none at all.  The available roles are:
 
+Overcloud admin network (``admin_oc_net_name``)
+    Name of the network used to access the overcloud for admin purposes, e.g
+    for remote SSH access.
 Overcloud out-of-band network (``oob_oc_net_name``)
     Name of the network used by the seed to access the out-of-band management
     controllers of the bare metal overcloud hosts.
@@ -440,6 +443,7 @@ To configure network roles in a system with two networks, ``example1`` and
 .. code-block:: yaml
    :caption: ``networks.yml``
 
+   admin_oc_net_name: example1
    oob_oc_net_name: example1
    provision_oc_net_name: example1
    oob_wl_net_name: example1
@@ -451,6 +455,31 @@ To configure network roles in a system with two networks, ``example1`` and
    storage_mgmt_net_name: example2
    inspection_net_name: example2
    cleaning_net_name: example2
+
+Overcloud Admin Network
+-----------------------
+
+The admin network is intended to be used for remote access to the overcloud hosts.
+Kayobe will use the address assigned to the host on this network as the
+``ansible_host`` when executing playbooks. It is therefore a necessary requirement
+to configure this network.
+
+By default Kayobe will use the overcloud provisioning network as the admin network.
+It is, however, possible to configure a separate network. To do so, you should
+override ``admin_oc_net_name`` in your networking configuration.
+
+If a separate network is configured, the following requirements should be taken into
+consideration:
+
+* The admin network must be configured to use the same physical network interface
+  as the provisioning network. This is because the PXE MAC address is used to
+  lookup the interface for the cloud-init network configuration that occurs
+  during bifrost provisioning of the overcloud.
+
+* If the admin network is configured as a tagged VLAN, you must configure Kayobe
+  to upgrade cloud-init. This is a temporary workaround for a bug in the current
+  version of cloud-init shipped with CentOS 7.5. Please see :ref:`workaround-cloud-init`
+  for more details.
 
 Overcloud Provisioning Network
 ------------------------------
@@ -593,6 +622,7 @@ Seed
 
 By default, the seed is attached to the following networks:
 
+* overcloud admin network
 * overcloud out-of-band network
 * overcloud provisioning network
 
@@ -617,7 +647,7 @@ Controllers
 
 By default, controllers are attached to the following networks:
 
-* overcloud provisioning network
+* overcloud admin network
 * workload (compute) out-of-band network
 * workload (compute) provisioning network
 * workload (compute) cleaning network
@@ -644,7 +674,7 @@ controllers when they are in the ``controllers`` group.  If the monitoring
 hosts are not in the ``controllers`` group, they are attached to the following
 networks by default:
 
-* overcloud provisioning network
+* overcloud admin network
 * internal network
 * public network
 
@@ -658,7 +688,7 @@ Virtualised Compute Hosts
 
 By default, virtualised compute hosts are attached to the following networks:
 
-* overcloud provisioning network
+* overcloud admin network
 * internal network
 * storage network
 

--- a/doc/source/deployment.rst
+++ b/doc/source/deployment.rst
@@ -133,6 +133,8 @@ image name regular expressions::
 In order to push images to a registry after they are built, add the ``--push``
 argument.
 
+.. _workaround-cloud-init:
+
 Workaround VLAN cloud-init issue
 --------------------------------
 

--- a/etc/kayobe/networks.yml
+++ b/etc/kayobe/networks.yml
@@ -4,6 +4,9 @@
 ###############################################################################
 # Network role to network mappings.
 
+# Name of the network used for admin access to the overcloud
+#admin_oc_net_name:
+
 # Name of the network used by the seed to manage the bare metal overcloud
 # hosts via their out-of-band management controllers.
 #oob_oc_net_name:
@@ -49,6 +52,15 @@
 
 ###############################################################################
 # Network definitions.
+
+# Admin network IP information.
+# admin_oc_net_cidr:
+# admin_oc_net_allocation_pool_start:
+# admin_oc_net_allocation_pool_end:
+# admin_oc_net_gateway:
+# admin_oc_net_vlan:
+# admin_oc_net_mtu:
+# admin_oc_net_routes:
 
 # Overcloud out-of-band management network IP information.
 # oob_oc_net_cidr:

--- a/releasenotes/notes/add-admin-network.yml-cf4b5e6387d0eb3f.yaml
+++ b/releasenotes/notes/add-admin-network.yml-cf4b5e6387d0eb3f.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Adds a new overcloud admin network to improve network separation.
+    The network is intended to be used for remote admin access e.g SSH.
+    If ``admin_oc_net_name`` is not set, Kayobe will use the previous
+    behaviour of using the overcloud provisioning network for this purpose.
+    See `Story 2002096
+    <https://storyboard.openstack.org/#!/story/2002096>`_


### PR DESCRIPTION
The admin network is intended for remote admin access to
the overcloud hosts e.g SSH. If admin_oc_net_name is not set
it will default to provision_oc_net_name for backwards
compatability.

Story: 2002096
Task: 19774

Change-Id: Ib04bbc07f97218d7503000cc363624c60c287822