### PR TITLE
Support dhcp-hostsdir option in inspector dnsmasq template

### DIFF
--- a/ansible/roles/kolla-openstack/templates/ironic-dnsmasq.conf.j2
+++ b/ansible/roles/kolla-openstack/templates/ironic-dnsmasq.conf.j2
@@ -28,6 +28,10 @@ dhcp-option=option:bootfile-name,{{ ironic_dnsmasq_boot_file | default('undionly
 dhcp-option=option:bootfile-name,{{ ironic_dnsmasq_boot_file | default('pxelinux.0') }}
 {% endif %}{% endraw %}
 
+{% raw %}{% if ironic_inspector_pxe_filter | default == 'dnsmasq' %}
+dhcp-hostsdir=/etc/dnsmasq/dhcp-hostsdir
+{% endif %}{% endraw %}
+
 {% if kolla_extra_ironic_dnsmasq %}
 {{ kolla_extra_ironic_dnsmasq }}
 {% endif %}


### PR DESCRIPTION
This is required if the Ironic Inspector dnsmasq PXE filter is in use.

Change-Id: I35f19f447584540860be1989abcae3d6882b98c1