### PR TITLE
Fix kayobe overcloud service config save

### DIFF
--- a/ansible/overcloud-service-config-save.yml
+++ b/ansible/overcloud-service-config-save.yml
@@ -16,9 +16,13 @@
         paths: "{{ node_config_directory }}"
         recurse: True
       register: find_result
+      become: true
 
     - name: Save overcloud service configuration
       fetch:
         src: "{{ item.path }}"
         dest: "{{ config_save_path }}"
       with_items: "{{ find_result.files }}"
+      become: true
+      loop_control:
+        label: "{{ item.path }}"


### PR DESCRIPTION
If Kolla Ansible config files are not readable by the kayobe (stack)
user, the command will fail. This is fixed by using become.

Also improves the command output, by showing only the path of each file
rather than the full stat result.

Change-Id: I466e6a75822a1b2d2f91c9fadc9730c2cdb5bba0
TrivialFix