### PR TITLE
Use seperate venv for ipa-images role

### DIFF
--- a/ansible/overcloud-ipa-images.yml
+++ b/ansible/overcloud-ipa-images.yml
@@ -95,7 +95,7 @@
         - item.src != item.dest
   roles:
     - role: ipa-images
-      ipa_images_venv: "{{ virtualenv_path }}/shade"
+      ipa_images_venv: "{{ virtualenv_path }}/ipa-images"
       ipa_images_openstack_auth_type: "{{ openstack_auth_type }}"
       ipa_images_openstack_auth: "{{ openstack_auth }}"
       ipa_images_openstack_auth_env: "{{ openstack_auth_env }}"


### PR DESCRIPTION
The packages in the shade venv seem to be constrained by:

https://raw.githubusercontent.com/openstack/requirements/stable/pike/upper-constraints.txt

This pins openstacksdk to 0.9.17. There is a compatbility issue with later versions of
Ansible (versions known not to work include ansible>=2.5), where you see an error similar to:
```
TASK [ipa-images : Gather facts about Ironic Python Agent (IPA) kernel image] **********************************************************************************************
fatal: [sv-b16-u23]: FAILED! => {"changed": false, "module_stderr": "Shared connection to 10.41.253.103 closed.\r\n", "module_stdout": "Traceback (most recent call last):\r
\n  File \"/home/stack/.ansible/tmp/ansible-tmp-1535972258.69-213326546118090/AnsiballZ_os_image_facts.py\", line 113, in <module>\r\n    _ansiballz_main()\r\n  File \"/hom
e/stack/.ansible/tmp/ansible-tmp-1535972258.69-213326546118090/AnsiballZ_os_image_facts.py\", line 105, in _ansiballz_main\r\n    invoke_module(zipped_mod, temp_path, ANSIB
ALLZ_PARAMS)\r\n  File \"/home/stack/.ansible/tmp/ansible-tmp-1535972258.69-213326546118090/AnsiballZ_os_image_facts.py\", line 48, in invoke_module\r\n    imp.load_module(
'__main__', mod, module, MOD_DESC)\r\n  File \"/tmp/ansible_os_image_facts_payload_GPK6Jg/__main__.py\", line 166, in <module>\r\n  File \"/tmp/ansible_os_image_facts_paylo
ad_GPK6Jg/__main__.py\", line 150, in main\r\n  File \"/tmp/ansible_os_image_facts_payload_GPK6Jg/ansible_os_image_facts_payload.zip/ansible/module_utils/openstack.py\", li
ne 121, in openstack_cloud_from_module\r\nAttributeError: 'module' object has no attribute 'version'\r\n", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "
rc": 1}
```
See: https://github.com/ansible/ansible/issues/42189

Using a later version of openstacksdk fixes this issue.