### PR TITLE
Check glance ids of deployment images after upload

### DIFF
--- a/ansible/roles/ipa-images/tasks/set-driver-info.yml
+++ b/ansible/roles/ipa-images/tasks/set-driver-info.yml
@@ -1,5 +1,23 @@
 ---
 
+- name: Retrieve deployment image uuids
+  os_image_facts:
+    auth_type: "{{ ipa_images_openstack_auth_type }}"
+    auth: "{{ ipa_images_openstack_auth }}"
+    image: "{{ item.name }}"
+  with_items:
+    - name: "{{ ipa_images_kernel_name }}"
+    - name: "{{ ipa_images_ramdisk_name }}"
+  register: ipa_images_glance
+
+- name: Set fact containing kernel uuid
+  set_fact:
+    ipa_images_kernel_uuid: "{{ ipa_images_glance.results[0].ansible_facts.openstack_image.id }}"
+
+- name: Set fact containing ramdisk uuid
+  set_fact:
+    ipa_images_ramdisk_uuid: "{{ ipa_images_glance.results[1].ansible_facts.openstack_image.id }}"
+
 - name: Get a list of ironic nodes
   command: |
     {{ ipa_images_venv }}/bin/openstack baremetal node list --fields name uuid driver_info -f json
@@ -33,13 +51,10 @@
 - name: Ensure ironic nodes use the new Ironic Python Agent (IPA) images
   command: >
     {{ ipa_images_venv }}/bin/openstack baremetal node set {{ item.UUID }}
-    --driver-info deploy_kernel={{ kernel_uuid }}
-    --driver-info deploy_ramdisk={{ ramdisk_uuid }}
+    --driver-info deploy_kernel={{ ipa_images_kernel_uuid }}
+    --driver-info deploy_ramdisk={{ ipa_images_ramdisk_uuid }}
   with_items: "{{ ipa_images_ironic_nodes }}"
-  vars:
-    ramdisk_uuid: "{{ ipa_images_new_images.results[1].id }}"
-    kernel_uuid: "{{ ipa_images_new_images.results[0].id }}"
   when:
-    item["Driver Info"].deploy_kernel != kernel_uuid or
-    item["Driver Info"].deploy_ramdisk != ramdisk_uuid
+    item["Driver Info"].deploy_kernel != ipa_images_kernel_uuid or
+    item["Driver Info"].deploy_ramdisk != ipa_images_ramdisk_uuid
   environment: "{{ ipa_images_openstack_auth_env }}"


### PR DESCRIPTION
This fixes an issue where you would see:

```
TASK [ipa-images : Ensure ironic nodes use the new Ironic Python Agent (IPA) images] ***************************************************************************************
fatal: [sv-b16-u23]: FAILED! => {"msg": "The conditional check 'item[\"Driver Info\"].deploy_kernel != kernel_uuid or item[\"Driver Info\"].deploy_ramdisk != ramdisk_uuid'
failed. The error was: error while evaluating conditional (item[\"Driver Info\"].deploy_kernel != kernel_uuid or item[\"Driver Info\"].deploy_ramdisk != ramdisk_uuid): 'dic
t object' has no attribute 'id'\n\nThe error appears to have been in '/home/will/kayobe-env-alt1/src/kayobe/ansible/roles/ipa-images/tasks/set-driver-info.yml': line 33, co
lumn 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Ensure ironic nodes use the new Ironic Py
thon Agent (IPA) images\n  ^ here\n"}
```
when running `kayobe overcloud update deployment image` if the image already existed in glance. This is because the id field is unset in the dictionary returned by os_image if an image with the same name already exists.

We now query glance to obtain the latest image uuids (even after upload).