### PR TITLE
Add Dell PowerConnect switch support

### DIFF
--- a/ansible/group_vars/switches/dell-powerconnect
+++ b/ansible/group_vars/switches/dell-powerconnect
@@ -1,0 +1,12 @@
+---
+# Switch configuration.
+
+###############################################################################
+# Authentication configuration.
+
+# For DellOS switches, this defines a 'provider' argument to the
+# dell_powerconnect_switch role.
+switch_dell_powerconnect_provider:
+  host: "{{ ansible_host }}"
+  username: "{{ ansible_user }}"
+  auth_pass: "{{ switch_auth_pass }}"

--- a/ansible/physical-network.yml
+++ b/ansible/physical-network.yml
@@ -81,6 +81,18 @@
       dell_switch_config: "{{ switch_config }}"
       dell_switch_interface_config: "{{ switch_interface_config }}"
 
+- name: Ensure Dell PowerConnect physical switches are configured
+  hosts: switches_of_type_dell-powerconnect:&switches_in_display_mode_False
+  gather_facts: no
+  roles:
+    - role: ssh-known-host
+
+    - role: stackhpc.dell-powerconnect-switch
+      dell_powerconnect_switch_type: "{{ switch_type }}"
+      dell_powerconnect_switch_provider: "{{ switch_dell_powerconnect_provider }}"
+      dell_powerconnect_switch_config: "{{ switch_config }}"
+      dell_powerconnect_switch_interface_config: "{{ switch_interface_config }}"
+
 - name: Ensure Juniper physical switches are configured
   hosts: switches_of_type_junos:&switches_in_display_mode_False
   gather_facts: no

--- a/releasenotes/notes/dell-powerconnect-switch-860fbcbf7e4323ea.yaml
+++ b/releasenotes/notes/dell-powerconnect-switch-860fbcbf7e4323ea.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds support for configuration of Dell PowerConnect switches. This is
+    integrated with the `kayobe physical network configure` command.

--- a/requirements.yml
+++ b/requirements.yml
@@ -13,6 +13,8 @@
 - src: singleplatform-eng.users
   version: v1.2.5
 - src: stackhpc.parted-1-1
+- src: stackhpc.dell-powerconnect-switch
+  version: v1.0.0
 - src: stackhpc.drac
   version: 1.1.4
 - src: stackhpc.drac-facts


### PR DESCRIPTION
We need this for the SIB pike deployment.

PowerConnect switches do not support the dellos Ansible modules, since
they are based on DellOS version 4. This role uses the expect module to
perform simple switch configuration.

Change-Id: Icb59aaff75f9faf089423610fecb06598f75e35e
Story: 2002106
Task: 19784