### PR TITLE
Add support for Dell PowerConnect switches in NGS

### DIFF
--- a/ansible/kolla-openstack.yml
+++ b/ansible/kolla-openstack.yml
@@ -86,6 +86,7 @@
   vars:
     switch_type_to_device_type:
       dellos9: netmiko_dell_force10
+      dell-powerconnect: netmiko_dell_powerconnect
       junos: netmiko_juniper
     ipa_image_name: "ipa"
   pre_tasks:


### PR DESCRIPTION
This depends on the support for Dell PowerConnect switches in
networking-generic-switch [1].

[1] https://review.openstack.org/573380

Change-Id: I2073a7f2b76c0cc064376564e7e47a5fd8530468
Story: 2002106
Task: 20051