### PR TITLE
Cherry/baremetal compute rename

### DIFF
--- a/ansible/baremetal-compute-inspect.yml
+++ b/ansible/baremetal-compute-inspect.yml
@@ -8,7 +8,7 @@
 
 - name: Ensure dependencies are installed and the virtual environment is activated
   hosts: controllers[0]
-  gather_facts: False
+  gather_facts: true
   vars:
     venv: "{{ virtualenv_path }}/shade"
   roles:

--- a/ansible/baremetal-compute-manage.yml
+++ b/ansible/baremetal-compute-manage.yml
@@ -8,7 +8,7 @@
 
 - name: Ensure baremetal compute nodes are available in ironic
   hosts: controllers[0]
-  gather_facts: False
+  gather_facts: true
   vars:
     venv: "{{ virtualenv_path }}/shade"
   roles:

--- a/ansible/baremetal-compute-provide.yml
+++ b/ansible/baremetal-compute-provide.yml
@@ -8,7 +8,7 @@
 
 - name: Ensure baremetal compute nodes are available in ironic
   hosts: controllers[0]
-  gather_facts: False
+  gather_facts: true
   vars:
     venv: "{{ virtualenv_path }}/shade"
   roles:

--- a/ansible/baremetal-compute-rename.yml
+++ b/ansible/baremetal-compute-rename.yml
@@ -1,0 +1,58 @@
+---
+# This playbook will ensure that all baremetal compute nodes are named after
+# their inventory host names. It matches the ipmi address in the inventory to
+# the one gathered from inspection
+
+- name: Rename baremetal compute nodes
+  hosts: controllers[0]
+  gather_facts: False
+  vars:
+    venv: "{{ virtualenv_path }}/openstack-cli"
+  pre_tasks:
+    - name: Set up openstack cli virtualenv
+      pip:
+        virtualenv: "{{ venv }}"
+        name:
+          - python-openstackclient
+          - python-ironicclient
+
+- name: Rename baremetal compute nodes
+  hosts: baremetal-compute
+  gather_facts: False
+  vars:
+    venv: "{{ virtualenv_path }}/openstack-cli"
+    controller_host: "{{ groups['controllers'][0] }}"
+  tasks:
+    - name: Fail if ipmi host variable not set
+      vars:
+        ipmi_address: "{{ hostvars[inventory_hostname].ipmi_address }}"
+      fail:
+        msg: >
+          The host variable, ipmi_address is not defined for {{ inventory_hostname }}. This variable is required
+          to run this playbook.
+      when: ipmi_address is not defined or not ipmi_address
+    - name: Get list of nodes
+      command: >
+        {{ venv }}/bin/openstack baremetal node list -f json --fields uuid name driver_info
+      register: nodes
+      delegate_to: "{{ controller_host }}"
+      environment: "{{ openstack_auth_env }}"
+      run_once: true
+      changed_when: false
+      vars:
+        # NOTE: Without this, the controller's ansible_host variable will not
+        # be respected when using delegate_to.
+        ansible_host: "{{ hostvars[controller_host].ansible_host | default(controller_host) }}"
+
+    - name: Rename baremetal compute nodes
+      command: >
+        {{ venv }}/bin/openstack baremetal node set --name "{{ inventory_hostname }}" "{{ node['UUID'] }}"
+      delegate_to: "{{ controller_host }}"
+      environment: "{{ openstack_auth_env }}"
+      vars:
+        # NOTE: Without this, the controller's ansible_host variable will not
+        # be respected when using delegate_to.
+        ansible_host: "{{ hostvars[controller_host].ansible_host | default(controller_host) }}"
+        ipmi_address: "{{ hostvars[inventory_hostname].ipmi_address }}"
+        node: "{{ (nodes.stdout | from_json) | selectattr('Driver Info.ipmi_address', 'equalto', ipmi_address) | first }}"
+      when: node['Name'] != inventory_hostname

--- a/ansible/baremetal-compute-rename.yml
+++ b/ansible/baremetal-compute-rename.yml
@@ -54,5 +54,8 @@
         # be respected when using delegate_to.
         ansible_host: "{{ hostvars[controller_host].ansible_host | default(controller_host) }}"
         ipmi_address: "{{ hostvars[inventory_hostname].ipmi_address }}"
-        node: "{{ (nodes.stdout | from_json) | selectattr('Driver Info.ipmi_address', 'equalto', ipmi_address) | first }}"
-      when: node['Name'] != inventory_hostname
+        matching_nodes: "{{ (nodes.stdout | from_json) | selectattr('Driver Info.ipmi_address', 'defined') | selectattr('Driver Info.ipmi_address', 'equalto', ipmi_address) | list }}"
+        node: "{{ matching_nodes | first }}"
+      when:
+        - matching_nodes | length > 0
+        - node['Name'] != inventory_hostname

--- a/doc/source/administration.rst
+++ b/doc/source/administration.rst
@@ -169,6 +169,18 @@ compute nodes::
 
     (kayobe) $ kayobe baremetal compute inspect
 
+Rename
+------
+
+Once nodes have been discovered, it is helpful to associate them with a name
+to make them easier to work with. If you would like the nodes to be named
+according to their inventory host names, you can run the following command:
+
+    (kayobe) $ kayobe baremetal compute rename
+
+This command will use the ``ipmi_address`` host variable from the inventory
+to map the inventory host name to the correct node.
+
 .. _update_deployment_image:
 
 Update Deployment Image

--- a/kayobe/cli/commands.py
+++ b/kayobe/cli/commands.py
@@ -1191,3 +1191,11 @@ class BaremetalComputeUpdateDeploymentImage(KayobeAnsibleMixin, VaultMixin,
             )
         self.run_kayobe_playbooks(parsed_args, playbooks,
                                   extra_vars=extra_vars)
+
+class BaremetalComputeRename(KayobeAnsibleMixin, VaultMixin, Command):
+    """Rename baremetal compute nodes to match inventory hostname"""
+
+    def take_action(self, parsed_args):
+        self.app.LOG.debug("Renaming baremetal compute nodes")
+        playbooks = _build_playbook_list("baremetal-compute-rename")
+        self.run_kayobe_playbooks(parsed_args, playbooks)

--- a/kayobe/tests/unit/cli/test_commands.py
+++ b/kayobe/tests/unit/cli/test_commands.py
@@ -880,3 +880,21 @@ class TestCase(unittest.TestCase):
             ),
         ]
         self.assertEqual(expected_calls, mock_run.call_args_list)
+
+    @mock.patch.object(commands.KayobeAnsibleMixin,
+                       "run_kayobe_playbooks")
+    def test_baremetal_compute_rename(self, mock_run):
+        command = commands.BaremetalComputeRename(TestApp(), [])
+        parser = command.get_parser("test")
+        parsed_args = parser.parse_args([])
+        result = command.run(parsed_args)
+        self.assertEqual(0, result)
+        expected_calls = [
+            mock.call(
+                mock.ANY,
+                [
+                    "ansible/baremetal-compute-rename.yml",
+                ],
+            ),
+        ]
+        self.assertEqual(expected_calls, mock_run.call_args_list)

--- a/releasenotes/notes/feature-automatic-node-rename-fc5fbe0f7c38151c.yaml
+++ b/releasenotes/notes/feature-automatic-node-rename-fc5fbe0f7c38151c.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds a command to rename baremetal compute nodes to match
+    their inventory host name - ``kayobe baremetal compute rename``

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ kayobe.cli=
     baremetal_compute_manage = kayobe.cli.commands:BaremetalComputeManage
     baremetal_compute_provide = kayobe.cli.commands:BaremetalComputeProvide
     baremetal_compute_update_deployment_image = kayobe.cli.commands:BaremetalComputeUpdateDeploymentImage
+    baremetal_compute_rename = kayobe.cli.commands:BaremetalComputeRename
     control_host_bootstrap = kayobe.cli.commands:ControlHostBootstrap
     control_host_upgrade = kayobe.cli.commands:ControlHostUpgrade
     configuration_dump = kayobe.cli.commands:ConfigurationDump


### PR DESCRIPTION
LLDP renaming of nodes does not work with powerconnect switches. This is useful for the SIB deployment.