### PR TITLE
Fix empty kolla_overcloud_inventory_storage_groups

### DIFF
--- a/ansible/roles/kolla-ansible/templates/overcloud-top-level.j2
+++ b/ansible/roles/kolla-ansible/templates/overcloud-top-level.j2
@@ -60,7 +60,7 @@ ansible_python_interpreter={{ kolla_ansible_target_venv }}/bin/python
 {% endif %}
 {% endfor %}
 {% for group in kolla_overcloud_inventory_kolla_top_level_groups %}
-{% if group not in kolla_overcloud_inventory_top_level_group_map %}
+{% if not kolla_overcloud_inventory_top_level_group_map.get(group, {}).get('groups') %}
 # Empty group definition for {{ group }}.
 [{{ group }}]
 


### PR DESCRIPTION
In some cases we may have a kolla group defined in
'kolla_overcloud_inventory_top_level_group_map' which has no kayobe
groups mapped to it. This causes no entry to be added to the inventory
for the group.  If the group is referenced elsewhere in the inventory,
then Ansible will fail to parse the inventory file.

The specific case that failed was when setting
'kolla_overcloud_inventory_storage_groups' to an empty list.

This change ensures that we add an empty definition for the group in the
kolla inventory.

Change-Id: I8e797aa6c55f8cf0cf6d52a33f213d8131581fea
Story: 2002105
Task: 19783