### PR TITLE
Fix deploy image update for Ansible 2.4

### DIFF
--- a/ansible/roles/ipa-images/tasks/set-driver-info.yml
+++ b/ansible/roles/ipa-images/tasks/set-driver-info.yml
@@ -36,7 +36,7 @@
 
 - name: Set fact containing filtered list of nodes
   set_fact:
-    ipa_images_compute_node_whitelist: "{{ query('inventory_hostnames', ipa_images_compute_node_limit) | unique }}"
+    ipa_images_compute_node_whitelist: "{{ lookup('inventory_hostnames', ipa_images_compute_node_limit).split(',') | unique }}"
 
 - name: Initialise a fact containing the ironic nodes
   set_fact:


### PR DESCRIPTION
The query function was added in Ansible 2.5. lookup is essentially equivalent.

Change-Id: I4069027581ea6c54ad256273b047c8729e7d9a54