### PR TITLE
Update python dependencies in kolla-ansible virtualenv

### DIFF
--- a/ansible/roles/kolla-ansible/tasks/install.yml
+++ b/ansible/roles/kolla-ansible/tasks/install.yml
@@ -59,7 +59,7 @@
 - name: Ensure required Python packages are installed
   pip:
     requirements: "{{ kolla_ansible_venv }}/requirements.txt"
-    state: present
+    state: latest
     extra_args: "{% if kolla_upper_constraints_file %}-c {{ kolla_upper_constraints_file }}{% endif %}"
     virtualenv: "{{ kolla_ansible_venv }}"
 


### PR DESCRIPTION
If upgrading the kayobe control host environment via kayobe control host
upgrade, kolla-ansible will be upgraded in its virtual environment if the
specified source repo and version are different than those installed. However,
other dependencies, including will not be upgraded unless the version
constraints require it. Ansible is specified with an upper bound on the
version, so typically this will be satisfied during an upgrade and will not
trigger an upgrade.

This change uses the 'latest' state for the pip module to ensure packages are
updated.

Change-Id: Ica38a1cdfb57c4be81468607800b26fdf3209fe7
Story: 2003878
Task: 26737