### PR TITLE
Fix naming of Kolla install type config option

### DIFF
--- a/ansible/roles/kolla-build/templates/kolla-build.conf.j2
+++ b/ansible/roles/kolla-build/templates/kolla-build.conf.j2
@@ -6,7 +6,7 @@
 base={{ kolla_base_distro }}
 
 # Method of OpenStack install. Valid options are [ binary, source ]
-type={{ kolla_install_type }}
+install_type={{ kolla_install_type }}
 
 # Docker namespace to use for Kolla images.
 namespace={{ kolla_docker_namespace }}


### PR DESCRIPTION
It seems that this has been named install_type since the beginning [1].

[1] https://github.com/openstack/kolla/commit/
    620d610eaaf03217f3a038c031fe28ce43132166

Change-Id: Ie48546d0ef44e04ca0b1b8cd046acb2f127f38c9
Story: 2003904
Task: 26782