### PR TITLE
Remove extra configuration for InfluxDB

### DIFF
--- a/ansible/kolla-openstack.yml
+++ b/ansible/kolla-openstack.yml
@@ -106,7 +106,6 @@
             - { name: glance, file: glance.conf }
             - { name: grafana, file: grafana.ini }
             - { name: heat, file: heat.conf }
-            - { name: influxdb, file: influxdb.conf }
             - { name: inspector, file: ironic-inspector.conf }
             - { name: ironic, file: ironic.conf }
             - { name: ironic_dnsmasq, file: ironic/ironic-dnsmasq.conf }
@@ -215,7 +214,6 @@
       kolla_extra_grafana: "{{ kolla_extra_config.grafana | default }}"
       kolla_extra_heat: "{{ kolla_extra_config.heat | default }}"
       kolla_extra_inspector: "{{ kolla_extra_config.inspector | default }}"
-      kolla_extra_influxdb: "{{ kolla_extra_config.influxdb | default }}"
       kolla_extra_ironic: "{{ kolla_extra_config.ironic | default }}"
       kolla_extra_ironic_dnsmasq: "{{ kolla_extra_config.ironic_dnsmasq | default }}"
       kolla_extra_kafka: "{{ kolla_extra_config.kafka | default }}"

--- a/ansible/roles/kolla-openstack/defaults/main.yml
+++ b/ansible/roles/kolla-openstack/defaults/main.yml
@@ -81,9 +81,6 @@ kolla_enable_horizon:
 # Whether to enable InfluxDB.
 kolla_enable_influxdb:
 
-# Free form extra configuration to append to influxdb.conf.
-kolla_extra_influxdb:
-
 ###############################################################################
 # Ironic configuration.
 

--- a/ansible/roles/kolla-openstack/molecule/enable-everything/molecule.yml
+++ b/ansible/roles/kolla-openstack/molecule/enable-everything/molecule.yml
@@ -40,9 +40,6 @@ provisioner:
           foo=bar
         kolla_enable_horizon: true
         kolla_enable_influxdb: true
-        kolla_extra_influxdb: |
-          [extra-influxdb.conf]
-          foo=bar
         kolla_enable_ironic: true
         kolla_extra_ironic: |
           [extra-ironic.conf]

--- a/ansible/roles/kolla-openstack/molecule/enable-everything/tests/test_default.py
+++ b/ansible/roles/kolla-openstack/molecule/enable-everything/tests/test_default.py
@@ -65,7 +65,6 @@ def test_service_config_directory(host, path):
      'glance.conf',
      'grafana.ini',
      'heat.conf',
-     'influxdb.conf',
      'ironic.conf',
      'ironic-inspector.conf',
      'kafka.server.properties',

--- a/ansible/roles/kolla-openstack/tasks/config.yml
+++ b/ansible/roles/kolla-openstack/tasks/config.yml
@@ -20,7 +20,6 @@
     - { src: glance.conf.j2, dest: glance.conf, enabled: "{{ kolla_enable_glance }}" }
     - { src: grafana.ini.j2, dest: grafana.ini, enabled: "{{ kolla_enable_grafana }}" }
     - { src: heat.conf.j2, dest: heat.conf, enabled: "{{ kolla_enable_heat }}" }
-    - { src: influxdb.conf.j2, dest: influxdb.conf, enabled: "{{ kolla_enable_influxdb }}" }
     - { src: ironic.conf.j2, dest: ironic.conf, enabled: "{{ kolla_enable_ironic }}" }
     - { src: ironic-dnsmasq.conf.j2, dest: ironic/ironic-dnsmasq.conf, enabled: "{{ kolla_enable_ironic }}" }
     - { src: ironic-inspector.conf.j2, dest: ironic-inspector.conf, enabled: "{{ kolla_enable_ironic }}" }

--- a/ansible/roles/kolla-openstack/templates/influxdb.conf.j2
+++ b/ansible/roles/kolla-openstack/templates/influxdb.conf.j2
@@ -1,9 +1,0 @@
-# {{ ansible_managed }}
-
-{% if kolla_extra_influxdb %}
-#######################
-# Extra configuration
-#######################
-
-{{ kolla_extra_influxdb }}
-{% endif %}

--- a/ansible/roles/kolla-openstack/vars/main.yml
+++ b/ansible/roles/kolla-openstack/vars/main.yml
@@ -60,9 +60,9 @@ kolla_openstack_custom_config:
     patterns: "*"
     enabled: "{{ kolla_enable_horizon }}"
   # InfluxDB.
-  - src: "{{ kolla_extra_config_path }}/influxdb"
-    dest: "{{ kolla_node_custom_config_path }}/influxdb"
-    patterns: "*"
+  - src: "{{ kolla_extra_config_path }}/"
+    dest: "{{ kolla_node_custom_config_path }}/"
+    patterns: "influx*"
     enabled: "{{ kolla_enable_influxdb }}"
   # Storm.
   - src: "{{ kolla_extra_config_path }}/storm"


### PR DESCRIPTION
InfluxDB config file merging isn't supported in Kolla-Ansible because
it uses 'nested sections' which aren't supported by merge_configs. If
no override file is specified, Kayobe will write out an empty config
file which will then be used as the InfluxDB config file, breaking
InfluxDB. To prevent that happening this change removes the extra
config in Kayobe. It also fixes the directory to which the 'glob'
collected config is copied to, as Kolla-Ansible doesn't look for
Influxdb config files in the influxdb folder.

Story: 2003951
Task: 26868