### PR TITLE
Remove extra configuration for InfluxDB

### DIFF
--- a/ansible/roles/kolla-openstack/molecule/default/tests/test_default.py
+++ b/ansible/roles/kolla-openstack/molecule/default/tests/test_default.py
@@ -44,7 +44,6 @@ def test_service_config_directory(host, path):
      'grafana',
      'heat',
      'horizon',
-     'influxdb',
      'ironic',
      'kafka',
      'magnum',

--- a/ansible/roles/kolla-openstack/molecule/enable-everything/tests/test_default.py
+++ b/ansible/roles/kolla-openstack/molecule/enable-everything/tests/test_default.py
@@ -36,7 +36,6 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
      'grafana',
      'heat',
      'horizon',
-     'influxdb',
      'ironic',
      'kafka',
      'keystone',


### PR DESCRIPTION
InfluxDB config file merging isn't supported in Kolla-Ansible because
it uses 'nested sections' which aren't supported by merge_configs. If
no override file is specified, Kayobe will write out an empty config
file which will then be used as the InfluxDB config file, breaking
InfluxDB. To prevent that happening this change removes the extra
config in Kayobe. It also fixes the directory to which the 'glob'
collected config is copied to, as Kolla-Ansible doesn't look for
Influxdb config files in the influxdb folder.

Change-Id: Iee4b7987934045f0355b4a87cebaebc1aa2bbe77
Story: 2003951
Task: 26868