### PR TITLE
Fix inspector dnsmasq interface name

### DIFF
--- a/ansible/roles/kolla-ansible/defaults/main.yml
+++ b/ansible/roles/kolla-ansible/defaults/main.yml
@@ -127,7 +127,7 @@ kolla_overcloud_inventory_pass_through_host_vars_map:
   kolla_storage_interface: "storage_interface"
   kolla_cluster_interface: "cluster_interface"
   kolla_provision_interface: "provision_interface"
-  kolla_inspector_dnsmasq_interface: "inspector_dnsmasq_interface"
+  kolla_inspector_dnsmasq_interface: "ironic_dnsmasq_interface"
   kolla_dns_interface: "dns_interface"
   kolla_tunnel_interface: "tunnel_interface"
   kolla_neutron_external_interfaces: "neutron_external_interface"

--- a/ansible/roles/kolla-ansible/tests/test-defaults.yml
+++ b/ansible/roles/kolla-ansible/tests/test-defaults.yml
@@ -109,7 +109,7 @@
               - storage_interface
               - cluster_interface
               - provision_interface
-              - inspector_dnsmasq_interface
+              - ironic_dnsmasq_interface
               - dns_interface
               - tunnel_interface
               - bifrost_network_interface

--- a/ansible/roles/kolla-ansible/tests/test-extras.yml
+++ b/ansible/roles/kolla-ansible/tests/test-extras.yml
@@ -317,7 +317,7 @@
               - storage_interface
               - cluster_interface
               - provision_interface
-              - inspector_dnsmasq_interface
+              - ironic_dnsmasq_interface
               - dns_interface
               - tunnel_interface
               - bifrost_network_interface
@@ -401,7 +401,7 @@
           assert:
             that: item in inventory_lines
           with_items:
-            - test-controller ansible_host='"1.2.3.5"' network_interface='"eth0"' api_interface='"eth2"' storage_interface='"eth3"' cluster_interface='"eth4"' provision_interface='"eth8"' inspector_dnsmasq_interface='"eth9"' dns_interface='"eth5"' tunnel_interface='"eth10"' kolla_external_vip_interface='"eth1"' neutron_external_interface='"eth6,eth7"' neutron_bridge_name='"br0,br1"'
+            - test-controller ansible_host='"1.2.3.5"' network_interface='"eth0"' api_interface='"eth2"' storage_interface='"eth3"' cluster_interface='"eth4"' provision_interface='"eth8"' ironic_dnsmasq_interface='"eth9"' dns_interface='"eth5"' tunnel_interface='"eth10"' kolla_external_vip_interface='"eth1"' neutron_external_interface='"eth6,eth7"' neutron_bridge_name='"br0,br1"'
             - test-compute ansible_host='"1.2.3.6"' network_interface='"eth0"' api_interface='"eth2"' storage_interface='"eth3"' tunnel_interface='"eth6"' neutron_external_interface='"eth4,eth5"' neutron_bridge_name='"br0,br1"'
 
       always:


### PR DESCRIPTION
Kolla-ansible uses the variable 'ironic_dnsmasq_interface' to denote the
interface for the ironic inspector dnsmasq service. Previously kayobe was
incorrectly using the variable 'inspector_dnsmasq_interface', which caused
kolla-ansible to ignore it and use the API interface instead. This patch fixes
that.

Change-Id: I733a84759cd03b62659dbf2d7027b7be9e42e818