### PR TITLE
[cherry-pick] Add --disable-discovery argument to physical network

### DIFF
--- a/ansible/group_vars/switches/config
+++ b/ansible/group_vars/switches/config
@@ -18,7 +18,19 @@ switch_config: []
 # file.
 switch_interface_config: {}
 
-# Interface configuration for hardware discovery. After discovery Neutron owns
-# the configuration of these ports. Has the same format as
+# Interface configuration for enabling hardware discovery. After discovery
+# Neutron owns the configuration of these ports. Has the same format as
 # switch_interface_config.
+# [DEPRECATED] Use switch_interface_config_enable_discovery.
 switch_interface_config_discovery: {}
+
+# Interface configuration for enabling hardware discovery. After discovery
+# Neutron owns the configuration of these ports. Has the same format as
+# switch_interface_config.
+# [DEPRECATED NAME] switch_interface_config_discovery.
+switch_interface_config_enable_discovery: "{{ switch_interface_config_discovery }}"
+
+# Interface configuration for disabling hardware discovery. After discovery
+# Neutron owns the configuration of these ports. Has the same format as
+# switch_interface_config.
+switch_interface_config_disable_discovery: {}

--- a/ansible/physical-network.yml
+++ b/ansible/physical-network.yml
@@ -9,6 +9,9 @@
     # Set this variable to True to configure the network for hardware
     # discovery.
     physical_network_enable_discovery: False
+    # Set this variable to True to deconfigure the network for hardware
+    # discovery.
+    physical_network_disable_discovery: False
     # Set this variable to a comma-separated list of names of interfaces to
     # configure in order to restrict configuration to a subset of interfaces.
     physical_network_interface_limit: ''
@@ -53,11 +56,17 @@
       group_by:
         key: "switches_in_display_mode_{{ physical_network_display | bool }}"
 
-    - name: Add discovery interface configuration when performing discovery
+    - name: Add discovery interface configuration when enabling discovery
       set_fact:
         switch_interface_config: >
-          {{ switch_interface_config | combine(switch_interface_config_discovery) }}
+          {{ switch_interface_config | combine(switch_interface_config_enable_discovery) }}
       when: physical_network_enable_discovery | bool
+
+    - name: Add discovery interface configuration when disabling discovery
+      set_fact:
+        switch_interface_config: >
+          {{ switch_interface_config | combine(switch_interface_config_disable_discovery) }}
+      when: physical_network_disable_discovery | bool
 
     - name: Restrict switch interfaces to requested subset by name
       set_fact:

--- a/kayobe/cli/commands.py
+++ b/kayobe/cli/commands.py
@@ -228,14 +228,19 @@ class PhysicalNetworkConfigure(KayobeAnsibleMixin, VaultMixin, Command):
         group.add_argument("--display", action="store_true",
                            help="display the candidate configuration and exit "
                                 "without applying it")
-        group.add_argument("--enable-discovery", action="store_true",
-                           help="configure the network for hardware discovery")
         group.add_argument("--interface-limit",
                            help="limit the switch interfaces to be configured "
                                 "by interface name")
         group.add_argument("--interface-description-limit",
                            help="limit the switch interfaces to be configured "
                                 "by interface description")
+        discovery = parser.add_mutually_exclusive_group()
+        discovery.add_argument("--enable-discovery", action="store_true",
+                               help="configure the network for hardware "
+                                    "discovery")
+        discovery.add_argument("--disable-discovery", action="store_true",
+                               help="deconfigure the network for hardware "
+                                    "discovery")
         return parser
 
     def take_action(self, parsed_args):
@@ -244,6 +249,8 @@ class PhysicalNetworkConfigure(KayobeAnsibleMixin, VaultMixin, Command):
         extra_vars["physical_network_display"] = parsed_args.display
         if parsed_args.enable_discovery:
             extra_vars["physical_network_enable_discovery"] = True
+        if parsed_args.disable_discovery:
+            extra_vars["physical_network_disable_discovery"] = True
         if parsed_args.interface_limit:
             extra_vars["physical_network_interface_limit"] = (
                 parsed_args.interface_limit)

--- a/kayobe/tests/unit/cli/test_commands.py
+++ b/kayobe/tests/unit/cli/test_commands.py
@@ -68,6 +68,146 @@ class TestCase(unittest.TestCase):
         self.assertEqual(expected_calls, mock_run.call_args_list)
 
     @mock.patch.object(commands.KayobeAnsibleMixin,
+                       "run_kayobe_playbook")
+    def test_physical_network_configure(self, mock_run):
+        command = commands.PhysicalNetworkConfigure(TestApp(), [])
+        parser = command.get_parser("test")
+        parsed_args = parser.parse_args(["--group", "switches"])
+        result = command.run(parsed_args)
+        self.assertEqual(0, result)
+        expected_calls = [
+            mock.call(
+                mock.ANY,
+                "ansible/physical-network.yml",
+                limit="switches",
+                extra_vars={
+                    "physical_network_display": False
+                }
+            )
+        ]
+        self.assertEqual(expected_calls, mock_run.call_args_list)
+
+    @mock.patch.object(commands.KayobeAnsibleMixin,
+                       "run_kayobe_playbook")
+    def test_physical_network_configure_display(self, mock_run):
+        command = commands.PhysicalNetworkConfigure(TestApp(), [])
+        parser = command.get_parser("test")
+        parsed_args = parser.parse_args(["--group", "switches", "--display"])
+        result = command.run(parsed_args)
+        self.assertEqual(0, result)
+        expected_calls = [
+            mock.call(
+                mock.ANY,
+                "ansible/physical-network.yml",
+                limit="switches",
+                extra_vars={
+                    "physical_network_display": True
+                }
+            )
+        ]
+        self.assertEqual(expected_calls, mock_run.call_args_list)
+
+    @mock.patch.object(commands.KayobeAnsibleMixin,
+                       "run_kayobe_playbook")
+    def test_physical_network_configure_enable_disco(self, mock_run):
+        command = commands.PhysicalNetworkConfigure(TestApp(), [])
+        parser = command.get_parser("test")
+        parsed_args = parser.parse_args(
+            ["--group", "switches", "--enable-discovery"])
+        result = command.run(parsed_args)
+        self.assertEqual(0, result)
+        expected_calls = [
+            mock.call(
+                mock.ANY,
+                "ansible/physical-network.yml",
+                limit="switches",
+                extra_vars={
+                    "physical_network_display": False,
+                    "physical_network_enable_discovery": True
+                }
+            )
+        ]
+        self.assertEqual(expected_calls, mock_run.call_args_list)
+
+    @mock.patch.object(commands.KayobeAnsibleMixin,
+                       "run_kayobe_playbook")
+    def test_physical_network_configure_disable_disco(self, mock_run):
+        command = commands.PhysicalNetworkConfigure(TestApp(), [])
+        parser = command.get_parser("test")
+        parsed_args = parser.parse_args(
+            ["--group", "switches", "--disable-discovery"])
+        result = command.run(parsed_args)
+        self.assertEqual(0, result)
+        expected_calls = [
+            mock.call(
+                mock.ANY,
+                "ansible/physical-network.yml",
+                limit="switches",
+                extra_vars={
+                    "physical_network_display": False,
+                    "physical_network_disable_discovery": True
+                }
+            )
+        ]
+        self.assertEqual(expected_calls, mock_run.call_args_list)
+
+    def test_physical_network_configure_enable_disable_disco(self):
+        command = commands.PhysicalNetworkConfigure(TestApp(), [])
+        parser = command.get_parser("test")
+        self.assertRaises(
+            SystemExit,
+            parser.parse_args,
+            ["--group", "switches", "--enable-discovery",
+             "--disable-discovery"])
+
+    @mock.patch.object(commands.KayobeAnsibleMixin,
+                       "run_kayobe_playbook")
+    def test_physical_network_configure_interface_limit(self, mock_run):
+        command = commands.PhysicalNetworkConfigure(TestApp(), [])
+        parser = command.get_parser("test")
+        parsed_args = parser.parse_args(
+            ["--group", "switches", "--interface-limit", "eth0,eth1"])
+        result = command.run(parsed_args)
+        self.assertEqual(0, result)
+        expected_calls = [
+            mock.call(
+                mock.ANY,
+                "ansible/physical-network.yml",
+                limit="switches",
+                extra_vars={
+                    "physical_network_display": False,
+                    "physical_network_interface_limit": "eth0,eth1"
+                }
+            )
+        ]
+        self.assertEqual(expected_calls, mock_run.call_args_list)
+
+    @mock.patch.object(commands.KayobeAnsibleMixin,
+                       "run_kayobe_playbook")
+    def test_physical_network_configure_interface_description_limit(
+            self, mock_run):
+        command = commands.PhysicalNetworkConfigure(TestApp(), [])
+        parser = command.get_parser("test")
+        parsed_args = parser.parse_args(
+            ["--group", "switches",
+             "--interface-description-limit", "host1,host2"])
+        result = command.run(parsed_args)
+        self.assertEqual(0, result)
+        expected_calls = [
+            mock.call(
+                mock.ANY,
+                "ansible/physical-network.yml",
+                limit="switches",
+                extra_vars={
+                    "physical_network_display": False,
+                    "physical_network_interface_description_limit": (
+                        "host1,host2")
+                }
+            )
+        ]
+        self.assertEqual(expected_calls, mock_run.call_args_list)
+
+    @mock.patch.object(commands.KayobeAnsibleMixin,
                        "run_kayobe_playbooks")
     def test_network_connectivity_check(self, mock_run):
         command = commands.NetworkConnectivityCheck(TestApp(), [])

--- a/releasenotes/notes/physical-network-disable-discovery-15916760e0a4d0bc.yaml
+++ b/releasenotes/notes/physical-network-disable-discovery-15916760e0a4d0bc.yaml
@@ -1,0 +1,14 @@
+---
+features:
+  - |
+    Adds support for a ``--disable-discovery`` argument to the ``kayobe
+    physical network configure`` command. This can be used to configure the
+    physical network after discovery of bare metal compute nodes is complete,
+    to return the network to a normal state. The interface configuration to be
+    applied is configured via ``switch_interface_config_disable_discovery``.
+deprecations:
+  - |
+    The switch configuration variable ``switch_interface_config_discovery`` has
+    been deprecated in favour of ``switch_interface_config_enable_discovery``.
+    Support for ``switch_interface_config_discovery`` will be removed in the T*
+    release.


### PR DESCRIPTION
Adds support for a '--disable-discovery' argument to the 'kayobe
physical network configure' command. This can be used to configure the
physical network after discovery of bare metal compute nodes is
complete, to return the network to a normal state. The interface
configuration to be applied is configured via
'switch_interface_config_disable_discovery'.

Essentially, this is the mirror of the '--enable-discovery' argument.

Change-Id: I40426a8fd22e51e8ea3350013a614dfbcf2afccf
Story: 2004048
Task: 27054
(cherry picked from e3e48e93ce2a7f6d7a4f76ee38d0017201821612)