### PR TITLE
Seed hypervisor user bootstrapping skipped

### DIFF
--- a/ansible/kayobe-ansible-user.yml
+++ b/ansible/kayobe-ansible-user.yml
@@ -7,7 +7,7 @@
 # bootstrap process if the account is inaccessible.
 
 - name: Determine whether user bootstrapping is required
-  hosts: seed:overcloud
+  hosts: seed-hypervisor:seed:overcloud
   gather_facts: false
   tags:
     - kayobe-ansible-user
@@ -62,7 +62,7 @@
       become: True
 
 - name: Verify that the Kayobe Ansible user account is accessible
-  hosts: seed:overcloud
+  hosts: seed-hypervisor:seed:overcloud
   gather_facts: false
   tags:
     - kayobe-ansible-user

--- a/releasenotes/notes/seed-hypervisor-bootstrap-58bafc1ea0d125bc.yaml
+++ b/releasenotes/notes/seed-hypervisor-bootstrap-58bafc1ea0d125bc.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes an issue where the seed hypervisor user bootstrapping is not
+    performed when executing ``kayobe seed hypervisor host configure``. See
+    `story 2004401 <https://storyboard.openstack.org/#!/story/2004401>`__ for
+    details.


### PR DESCRIPTION
Although the 'kayobe seed hypervisor host configure' command executes
the kayobe-ansible-user.yml playbook correctly, the playbook does not
have the seed-hypervisor group in its host list, so it is a noop. This
change fixes that.

Change-Id: I30a83a9851345ece061413d3c1751112247425ae
Story: 2004401
Task: 28034
(cherry picked from commit 5f791a4b46ddf15c35770af4df58139f15a8c9cf)