### PR TITLE
Retry adding custom repos until success

### DIFF
--- a/ansible/roles/yum/tasks/custom_repo.yml
+++ b/ansible/roles/yum/tasks/custom_repo.yml
@@ -24,5 +24,5 @@
   register: register_yum_command
   retries: 3
   delay: 10
-  until: "'failed' not in register_yum_command"
+  until: register_yum_command is success
   become: true


### PR DESCRIPTION
Previously we checked for false in the result. The behavior
of Ansible has probably changed, as failed is always in the
result dictionary - just with the value "false". Tested
with Ansible 2.5.11.

Change-Id: Idfa2f33dd6641031ea8a287d74b6dbbfa578c9ab
(cherry picked from commit a2dd79f8b100384ea83c7835688a5795eea90ba6)