### PR TITLE
Update grafana-conf role

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -19,7 +19,7 @@
 - src: stackhpc.drac-facts
   version: 1.0.0
 - src: stackhpc.grafana-conf
-  version: 1.0
+  version: 1.1.0
 - src: stackhpc.libvirt-host
   version: v1.1.0
 - src: stackhpc.libvirt-vm


### PR DESCRIPTION
Ansible Galaxy switched to semantic versioning. In order to get it
to import the latest release, a tag following this scheme was added
after a minor update to the grafana-conf role. This appears to have
broken the accessibility of the original version. This commit moves
to the later release to work around the issue.

Change-Id: I5a0ba9e18bc5db54f899b545b88c319c7922bf9e