### PR TITLE
Fix physical network configuration on Dell switches

### DIFF
--- a/ansible/group_vars/all/switches/dell
+++ b/ansible/group_vars/all/switches/dell
@@ -10,6 +10,5 @@ switch_dellos_provider:
   host: "{{ ansible_host }}"
   username: "{{ ansible_user }}"
   password: "{{ ansible_ssh_pass }}"
-  transport: cli
   authorize: yes
   auth_pass: "{{ switch_auth_pass }}"

--- a/ansible/roles/dell-switch/README.md
+++ b/ansible/roles/dell-switch/README.md
@@ -57,7 +57,6 @@ passwords.  It applies global configuration for LLDP, and enables two
             host: "{{ switch_host }}"
             username: "{{ switch_user }}"
             password: "{{ switch_password }}"
-            transport: cli
             authorize: yes
             auth_pass: "{{ switch_auth_pass }}"
           dell_switch_config:

--- a/releasenotes/notes/fix-dell-physical-network-config-b4eaf752e62eeadb.yaml
+++ b/releasenotes/notes/fix-dell-physical-network-config-b4eaf752e62eeadb.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes a compatibility issue with Ansible modules for Dell switches which
+    was preventing physical network configuration for this type of hardware.
+    See `Story 2004588 <https://storyboard.openstack.org/#!/story/2004588>`__
+    for details.


### PR DESCRIPTION
The dellos Ansible modules do not accept a `transport` key in the
provider parameter anymore, even in Ansible 2.4.0.

Change-Id: I4bdaa337cb9c6cb93f36338a191a9aa78e2c13f0
Story: 2004588
Task: 28464
(cherry picked from commit c7743aa615f0b8a404c59e924a487a352be6badf)