### PR TITLE
Remove duplicate CLI command classes

### DIFF
--- a/kayobe/cli/commands.py
+++ b/kayobe/cli/commands.py
@@ -465,28 +465,6 @@ class SeedHostPackageUpdate(KayobeAnsibleMixin, VaultMixin, Command):
                                   extra_vars=extra_vars)
 
 
-class SeedHostPackageUpdate(KayobeAnsibleMixin, VaultMixin, Command):
-    """Update packages on the seed host."""
-
-    def get_parser(self, prog_name):
-        parser = super(SeedHostPackageUpdate, self).get_parser(prog_name)
-        group = parser.add_argument_group("Host Package Updates")
-        group.add_argument("--packages",
-                           help="List of packages to update. By default all "
-                                "packages will be updated.")
-        return parser
-
-    def take_action(self, parsed_args):
-        self.app.LOG.debug("Updating seed host packages")
-        extra_vars = {}
-        if parsed_args.packages:
-            extra_vars["host_package_update_packages"] = (
-                parsed_args.packages)
-        playbooks = _build_playbook_list("host-package-update")
-        self.run_kayobe_playbooks(parsed_args, playbooks, limit="seed",
-                                  extra_vars=extra_vars)
-
-
 class SeedHostUpgrade(KollaAnsibleMixin, KayobeAnsibleMixin, VaultMixin,
                       Command):
     """Upgrade the seed host services.
@@ -857,28 +835,6 @@ class OvercloudHostPackageUpdate(KayobeAnsibleMixin, VaultMixin, Command):
             "host_package_update_packages": parsed_args.packages,
             "host_package_update_security": parsed_args.security,
         }
-        playbooks = _build_playbook_list("host-package-update")
-        self.run_kayobe_playbooks(parsed_args, playbooks, limit="overcloud",
-                                  extra_vars=extra_vars)
-
-
-class OvercloudHostPackageUpdate(KayobeAnsibleMixin, VaultMixin, Command):
-    """Update packages on the overcloud hosts."""
-
-    def get_parser(self, prog_name):
-        parser = super(OvercloudHostPackageUpdate, self).get_parser(prog_name)
-        group = parser.add_argument_group("Host Package Updates")
-        group.add_argument("--packages",
-                           help="List of packages to update. By default all "
-                                "packages will be updated.")
-        return parser
-
-    def take_action(self, parsed_args):
-        self.app.LOG.debug("Updating overcloud host packages")
-        extra_vars = {}
-        if parsed_args.packages:
-            extra_vars["host_package_update_packages"] = (
-                parsed_args.packages)
         playbooks = _build_playbook_list("host-package-update")
         self.run_kayobe_playbooks(parsed_args, playbooks, limit="overcloud",
                                   extra_vars=extra_vars)


### PR DESCRIPTION
These were likely added during a bad code merge, and cause unit tests to fail.

Change-Id: I4aaf66e4a5881cf63127c47dd646cad647898fbe