### PR TITLE
Victoria backport multienv

### DIFF
--- a/ansible/baremetal-compute-serial-console.yml
+++ b/ansible/baremetal-compute-serial-console.yml
@@ -47,7 +47,7 @@
            console_allocation_pool_start: "{{ ironic_serial_console_tcp_pool_start }}"
            console_allocation_pool_end: "{{ ironic_serial_console_tcp_pool_end }}"
            console_allocation_ironic_nodes: "{{ baremetal_nodes }}"
-           console_allocation_filename: "{{ kayobe_config_path }}/console-allocation.yml"
+           console_allocation_filename: "{{ kayobe_env_config_path }}/console-allocation.yml"
       when: cmd == "enable"
 
 - name: Enable serial console

--- a/ansible/group_vars/all/globals
+++ b/ansible/group_vars/all/globals
@@ -7,6 +7,15 @@
 # Path to Kayobe configuration directory on Ansible control host.
 kayobe_config_path: "{{ lookup('env', 'KAYOBE_CONFIG_PATH') | default('/etc/kayobe', true) }}"
 
+# Name of Kayobe environment to use. Default is $KAYOBE_ENVIRONMENT, or an
+# empty string if $KAYOBE_ENVIRONMENT is not set. Can also be set via the
+# --environment argument when invoking kayobe.
+kayobe_environment: "{{ lookup('env', 'KAYOBE_ENVIRONMENT') }}"
+
+# Path to Kayobe configuration directory on Ansible control host with an
+# environment path appended if kayobe_environment is set.
+kayobe_env_config_path: "{{ kayobe_config_path ~ ('/environments/' ~ kayobe_environment if kayobe_environment else '') }}"
+
 ###############################################################################
 # Remote path configuration (seed, seed-hypervisor and overcloud hosts).
 

--- a/ansible/group_vars/all/seed
+++ b/ansible/group_vars/all/seed
@@ -109,7 +109,7 @@ seed_users: "{{ users_default }}"
 #   squid:
 #     name: "squid"
 #     image: "stackhpc/squid:3.5.20-1"
-#     pre: "{{ kayobe_config_path }}/containers/squid/pre.yml"
-#     post: "{{ kayobe_config_path }}/containers/squid/post.yml"
+#     pre: "{{ kayobe_env_config_path }}/containers/squid/pre.yml"
+#     post: "{{ kayobe_env_config_path }}/containers/squid/post.yml"
 #
 seed_containers: {}

--- a/ansible/ip-allocation.yml
+++ b/ansible/ip-allocation.yml
@@ -29,5 +29,5 @@
         - item | net_bootproto != 'dhcp'
   roles:
     - role: ip-allocation
-      ip_allocation_filename: "{{ kayobe_config_path }}/network-allocation.yml"
+      ip_allocation_filename: "{{ kayobe_env_config_path }}/network-allocation.yml"
       ip_allocation_hostname: "{{ inventory_hostname }}"

--- a/ansible/kolla-ansible.yml
+++ b/ansible/kolla-ansible.yml
@@ -38,7 +38,7 @@
     - block:
         - name: Check whether a Kolla extra globals configuration file exists
           stat:
-            path: "{{ kayobe_config_path ~ '/kolla/globals.yml' }}"
+            path: "{{ kayobe_env_config_path ~ '/kolla/globals.yml' }}"
             get_checksum: False
             get_md5: False
             mime: False
@@ -46,7 +46,7 @@
 
         - name: Read the Kolla extra globals configuration file
           set_fact:
-            kolla_extra_globals: "{{ lookup('template', kayobe_config_path ~ '/kolla/globals.yml') | from_yaml }}"
+            kolla_extra_globals: "{{ lookup('template', kayobe_env_config_path ~ '/kolla/globals.yml') | from_yaml }}"
           when: globals_stat.stat.exists
       tags:
         - config
@@ -102,9 +102,9 @@
         kolla_ansible_install_epel: "{{ dnf_install_epel }}"
         kolla_external_fqdn_cert: "{{ kolla_config_path }}/certificates/haproxy.pem"
         kolla_internal_fqdn_cert: "{{ kolla_config_path }}/certificates/haproxy-internal.pem"
-        kolla_ansible_passwords_path: "{{ kayobe_config_path }}/kolla/passwords.yml"
-        kolla_overcloud_group_vars_path: "{{ kayobe_config_path }}/kolla/inventory/group_vars"
-        kolla_ansible_certificates_path: "{{ kayobe_config_path }}/kolla/certificates"
+        kolla_ansible_passwords_path: "{{ kayobe_env_config_path }}/kolla/passwords.yml"
+        kolla_overcloud_group_vars_path: "{{ kayobe_env_config_path }}/kolla/inventory/group_vars"
+        kolla_ansible_certificates_path: "{{ kayobe_env_config_path }}/kolla/certificates"
         # NOTE: This differs from the default SELinux mode in kolla ansible,
         # which is permissive. The justification for using this mode is twofold:
         # 1. it avoids filling up the audit log

--- a/ansible/kolla-ansible.yml
+++ b/ansible/kolla-ansible.yml
@@ -34,8 +34,30 @@
     # gracefully.
     network_host: "{{ groups['network'][0] }}"
   pre_tasks:
-    # Configuration of extra user-provided Kolla globals.
     - block:
+        - name: Look for environment file in Kolla configuration path
+          stat:
+            path: "{{ kolla_config_path ~ '/.environment' }}"
+            get_checksum: False
+            get_md5: False
+            mime: False
+          register: kolla_environment_file
+
+        - name: Flag that the Kolla configuration path has been used by another environment
+          vars:
+            kolla_environment: "{{ lookup('file', kolla_config_path ~ '/.environment') }}"
+          fail:
+            msg: >
+              The Kolla configuration path at {{ kolla_config_path }} was
+              already used by environment {{ kolla_environment }}. You should
+              clean up this directory, including the environment file located
+              at {{ kolla_config_path ~ '/.environment' }}, before running
+              Kayobe again.
+          when:
+            - kolla_environment_file.stat.exists
+            - kolla_environment != kayobe_environment
+
+        # Configuration of extra user-provided Kolla globals.
         - name: Check whether a Kolla extra globals configuration file exists
           stat:
             path: "{{ kayobe_env_config_path ~ '/kolla/globals.yml' }}"

--- a/ansible/kolla-bifrost.yml
+++ b/ansible/kolla-bifrost.yml
@@ -4,7 +4,7 @@
   tags:
     - kolla-bifrost
   vars:
-    kolla_bifrost_extra_globals_path: "{{ kayobe_config_path ~ '/kolla/config/bifrost/bifrost.yml' }}"
+    kolla_bifrost_extra_globals_path: "{{ kayobe_env_config_path ~ '/kolla/config/bifrost/bifrost.yml' }}"
 
   pre_tasks:
     - name: Check whether a Kolla Bifrost extra globals configuration file exists

--- a/ansible/kolla-build.yml
+++ b/ansible/kolla-build.yml
@@ -7,4 +7,4 @@
     - role: kolla
       kolla_install_epel: "{{ dnf_install_epel }}"
     - role: kolla-build
-      kolla_build_extra_config_path: "{{ kayobe_config_path }}/kolla/kolla-build.conf"
+      kolla_build_extra_config_path: "{{ kayobe_env_config_path }}/kolla/kolla-build.conf"

--- a/ansible/kolla-openstack.yml
+++ b/ansible/kolla-openstack.yml
@@ -101,7 +101,7 @@
     - block:
         - name: Check whether Kolla extra configuration files exist
           stat:
-            path: "{{ kayobe_config_path }}/kolla/config/{{ item.file }}"
+            path: "{{ kayobe_env_config_path }}/kolla/config/{{ item.file }}"
             get_checksum: False
             get_md5: False
             mime: False
@@ -245,4 +245,4 @@
       kolla_extra_octavia: "{{ kolla_extra_config.octavia | default }}"
       kolla_extra_sahara: "{{ kolla_extra_config.sahara | default }}"
       kolla_extra_zookeeper: "{{ kolla_extra_config.zookeeper | default }}"
-      kolla_extra_config_path: "{{ kayobe_config_path }}/kolla/config"
+      kolla_extra_config_path: "{{ kayobe_env_config_path }}/kolla/config"

--- a/ansible/overcloud-grafana-configure.yml
+++ b/ansible/overcloud-grafana-configure.yml
@@ -71,7 +71,7 @@
       when: not kolla_enable_haproxy | bool
 
     - name: Include Kolla passwords for Grafana local admin account credentials
-      include_vars: "{{ kayobe_config_path }}/kolla/passwords.yml"
+      include_vars: "{{ kayobe_env_config_path }}/kolla/passwords.yml"
   roles:
     - role: stackhpc.grafana-conf
       grafana_conf_organisation: "{{ grafana_control_plane_organisation }}"

--- a/ansible/overcloud-inventory-discover.yml
+++ b/ansible/overcloud-inventory-discover.yml
@@ -53,4 +53,4 @@
           {% endfor %}
 
           {% endfor %}
-        dest: "{{ kayobe_config_path }}/inventory/overcloud"
+        dest: "{{ kayobe_env_config_path }}/inventory/overcloud"

--- a/ansible/roles/kolla-ansible/tasks/config.yml
+++ b/ansible/roles/kolla-ansible/tasks/config.yml
@@ -40,6 +40,13 @@
     - "{{ kolla_overcloud_inventory_path }}/group_vars"
     - "{{ kolla_node_custom_config_path }}"
 
+- name: Write environment file into Kolla configuration path
+  copy:
+    dest: "{{ kolla_config_path ~ '/.environment' }}"
+    content: |
+      {{ kayobe_environment }}
+  when: (kayobe_environment | default('')) | length > 0
+
 - name: Ensure the Kolla global configuration file exists
   template:
     src: "globals.yml.j2"

--- a/ansible/swift-rings.yml
+++ b/ansible/swift-rings.yml
@@ -31,5 +31,5 @@
     - include_role:
         name: swift-rings
       vars:
-        swift_config_path: "{{ kayobe_config_path }}/kolla/config/swift"
+        swift_config_path: "{{ kayobe_env_config_path }}/kolla/config/swift"
       when: kolla_enable_swift | bool

--- a/dev/environment-setup.sh
+++ b/dev/environment-setup.sh
@@ -11,6 +11,9 @@ set -o pipefail
 # environment. This script should be sourced rather than executed in a
 # subprocess. e.g. source dev/environment-setup.sh
 
+# Arguments passed to this script are passed through to the kayobe-env script
+# in kayobe-config. This can be used to set the Kayobe environment.
+
 PARENT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 source "${PARENT}/functions"
@@ -18,10 +21,10 @@ source "${PARENT}/functions"
 
 function main {
     config_init
-    environment_setup
+    environment_setup "$@"
 }
 
-main
+main "$@"
 
 # Restore previous shell options.
 eval "$oldstate"

--- a/dev/functions
+++ b/dev/functions
@@ -214,7 +214,7 @@ function environment_setup {
     set +u
     source "${KAYOBE_VENV_PATH}/bin/activate"
     set -u
-    source "${KAYOBE_CONFIG_SOURCE_PATH}/kayobe-env"
+    source "${KAYOBE_CONFIG_SOURCE_PATH}/kayobe-env" "$@"
 }
 
 function run_kayobe {

--- a/doc/source/configuration/reference/seed-custom-containers.rst
+++ b/doc/source/configuration/reference/seed-custom-containers.rst
@@ -18,8 +18,8 @@ For example, to deploy a squid container image:
    seed_containers:
      squid:
        image: "stackhpc/squid:3.5.20-1"
-       pre: "{{ kayobe_config_path }}/containers/squid/pre.yml"
-       post: "{{ kayobe_config_path }}/containers/squid/post.yml"
+       pre: "{{ kayobe_env_config_path }}/containers/squid/pre.yml"
+       post: "{{ kayobe_env_config_path }}/containers/squid/post.yml"
 
 Please notice the *optional* pre and post Ansible task files - those need to
 be created in ``kayobe-config`` path and will be run before and after

--- a/doc/source/control-plane-service-placement.rst
+++ b/doc/source/control-plane-service-placement.rst
@@ -241,7 +241,7 @@ Next, we must configure kayobe to use this inventory template.
 .. code-block:: yaml
    :caption: ``kolla.yml``
 
-   kolla_overcloud_inventory_custom_components: "{{ lookup('template', kayobe_config_path ~ '/kolla/inventory/overcloud-components.j2') }}"
+   kolla_overcloud_inventory_custom_components: "{{ lookup('template', kayobe_env_config_path ~ '/kolla/inventory/overcloud-components.j2') }}"
 
 Here we use the ``template`` lookup plugin to render the Jinja2-formatted
 inventory template.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -45,6 +45,7 @@ Advanced Documentation
 
    control-plane-service-placement
    custom-ansible-playbooks
+   multiple-environments
 
 Contributor Guide
 -----------------

--- a/doc/source/multiple-environments.rst
+++ b/doc/source/multiple-environments.rst
@@ -2,6 +2,11 @@
 Multiple Environments
 =====================
 
+.. warning::
+
+    Support for multiple Kayobe environments is considered experimental: its
+    design may change in future versions without a deprecation period.
+
 Sometimes it can be useful to support deployment of multiple environments from
 a single Kayobe configuration. Most commonly this is to support a deployment
 pipeline, such as the traditional development, test, staging and production

--- a/doc/source/multiple-environments.rst
+++ b/doc/source/multiple-environments.rst
@@ -1,0 +1,265 @@
+=====================
+Multiple Environments
+=====================
+
+Sometimes it can be useful to support deployment of multiple environments from
+a single Kayobe configuration. Most commonly this is to support a deployment
+pipeline, such as the traditional development, test, staging and production
+combination. Since the Wallaby release, it is possible to include multiple
+environments within a single Kayobe configuration, each providing its own
+Ansible inventory and variables. This section describes how to use multiple
+environments with Kayobe.
+
+Defining Kayobe Environments
+============================
+
+By default, a Kayobe configuration directory contains a single environment,
+represented by the Ansible inventory located at
+``$KAYOBE_CONFIG_PATH/inventory``, extra variables files
+(``$KAYOBE_CONFIG_PATH/*.yml``), custom Ansible playbooks and hooks, and Kolla
+configuration.
+
+Supporting multiple environments is done through a
+``$KAYOBE_CONFIG_PATH/environments`` directory, under which each directory
+represents a different environment.  Each environment contains its own Ansible
+inventory, extra variable files, and Kolla configuration. The following layout
+shows two environments called ``staging`` and ``production`` within a single
+Kayobe configuration.
+
+.. code-block:: text
+
+   $KAYOBE_CONFIG_PATH/
+   └── environments/
+       ├── production/
+       │   ├── inventory/
+       │   │   ├── groups
+       │   │   ├── group_vars/
+       │   │   ├── hosts
+       │   │   ├── host_vars/
+       │   │   └── overcloud
+       │   ├── kolla/
+       │   │   ├── config/
+       │   │   ├── globals.yml
+       │   │   └── passwords.yml
+       │   ├── network-allocation.yml
+       │   ├── networks.yml
+       │   └── overcloud.yml
+       └── staging/
+           ├── inventory/
+           │   ├── groups
+           │   ├── group_vars/
+           │   ├── hosts
+           │   ├── host_vars/
+           │   └── overcloud
+           ├── kolla/
+           │   ├── config/
+           │   ├── globals.yml
+           │   └── passwords.yml
+           ├── network-allocation.yml
+           ├── networks.yml
+           └── overcloud.yml
+
+Ansible Inventories
+-------------------
+
+Each environment can include its own inventory, which overrides any variable
+declaration done in the shared inventory. Typically, a shared inventory may be
+used to define groups and group variables, while hosts and host variables would
+be set in enviroment inventories. The following layout (ignoring non-inventory
+files) shows an example of multiple inventories.
+
+.. code-block:: text
+
+   $KAYOBE_CONFIG_PATH/
+   ├── environments/
+   │   ├── production/
+   │   │   ├── inventory/
+   │   │   │   ├── hosts
+   │   │   │   ├── host_vars/
+   │   │   │   └── overcloud
+   │   └── staging/
+   │       ├── inventory/
+   │       │   ├── hosts
+   │       │   ├── host_vars/
+   │       │   └── overcloud
+   └── inventory/
+       ├── groups
+       └── group_vars/
+
+Shared Extra Variables Files
+----------------------------
+
+All of the extra variables files in the Kayobe configuration directory
+(``$KAYOBE_CONFIG_PATH/*.yml``) are shared between all environments. Each
+environment can override these extra variables through environment-specific
+extra variables files
+(``$KAYOBE_CONFIG_PATH/environments/<environment>/*.yml``).
+
+This means that all configuration in shared extra variable files must apply to
+all environments. Where configuration differs between environments, move the
+configuration to extra variables files under each environment.
+
+For example, to add environment-specific DNS configuration for variables in
+``dns.yml``, set these variables in
+``$KAYOBE_CONFIG_PATH/environments/<environment>/dns.yml``:
+
+.. code-block:: text
+
+   $KAYOBE_CONFIG_PATH/
+   ├── dns.yml
+   └── environments/
+       ├── production/
+       │   ├── dns.yml
+       └── staging/
+           └── dns.yml
+
+Network Configuration
+^^^^^^^^^^^^^^^^^^^^^
+
+Networking is an area in which configuration is typically specific to an
+environment. There are two main global configuration files that need to be
+considered: ``networks.yml`` and ``network-allocation.yml``.
+
+Move the environment-specific parts of this configuration to
+environment-specific extra variables files:
+
+* ``networks.yml`` -> ``$KAYOBE_CONFIG_PATH/environments/<environment>/networks.yml``
+* ``network-allocation.yml`` -> ``$KAYOBE_CONFIG_PATH/environments/<environment>/network-allocation.yml``
+
+Other network configuration that may differ between environments includes:
+
+* DNS (``dns.yml``)
+* network interface names, which may be set via group variables in environment
+  inventories
+
+Other Configuration
+^^^^^^^^^^^^^^^^^^^
+
+Typically it is necessary to customise ``overcloud_group_hosts_map`` in each
+environment. This is done via the ``overcloud.yml`` file documented in
+:ref:`control-plane-service-placement`.
+
+When using baremetal compute nodes, allocation of TCP ports for serial console
+functionality is typically specific to an environment
+(``console-allocation.yml``). This file is automatically managed by Kayobe,
+like the ``network-allocation.yml`` file.
+
+Kolla Configuration
+-------------------
+
+Kolla configuration is currently independent in each environment. To avoid
+duplicating configuration, symbolic links can be used to share common variable
+definitions. It is advised to avoid sharing credentials between environments by
+making each Kolla ``passwords.yml`` file unique.
+
+Custom Ansible Playbooks and Hooks
+----------------------------------
+
+The following files and directories are currently shared across all
+environments:
+
+* Ansible playbooks, roles and requirements file under
+  ``$KAYOBE_CONFIG_PATH/ansible``
+* Ansible configuration at ``$KAYOBE_CONFIG_PATH/ansible.cfg`` and
+  ``$KAYOBE_CONFIG_PATH/kolla/ansible.cfg``
+* Hooks under ``$KAYOBE_CONFIG_PATH/hooks``
+
+Dynamic Variable Definitions
+----------------------------
+
+It may be beneficial to define variables in a file shared by multiple
+environments, but still set variables to different values based on the
+environment. The Kayobe environment in use can be retrieved within Ansible via
+the ``kayobe_environment`` variable. For example, some variables from
+``$KAYOBE_CONFIG_PATH/networks.yml`` could be shared in the following way:
+
+.. code-block:: yaml
+   :caption: ``$KAYOBE_CONFIG_PATH/networks.yml``
+
+   external_net_fqdn: "{{ kayobe_environment }}-api.example.com"
+
+This would configure the external FQDN for the staging environment at
+``staging-api.example.com``, while the production external FQDN would be at
+``production-api.example.com``.
+
+Final Considerations
+--------------------
+
+While it's clearly desirable to keep staging functionally as close to
+production, this is not always possible due to resource constraints and other
+factors. Test and development environments can deviate further, perhaps only
+providing a subset of the functionality available in production, in a
+substantially different environment. In these cases it will clearly be
+necessary to use environment-specific configuration in a number of files. We
+can't cover all the cases here, but hopefully we've provided a set of
+techniques that can be used.
+
+Using Kayobe Environments
+=========================
+
+Once environments are defined, Kayobe can be instructed to manage them with the
+``$KAYOBE_ENVIRONMENT`` environment variable or the ``--environment``
+command-line argument:
+
+.. code-block:: console
+
+   (kayobe) $ kayobe control host bootstrap --environment staging
+
+.. code-block:: console
+
+   (kayobe) $ export KAYOBE_ENVIRONMENT=staging
+   (kayobe) $ kayobe control host bootstrap
+
+The ``kayobe-env`` environment file in ``kayobe-config`` can also take an
+``--environment`` argument, which exports the ``KAYOBE_ENVIRONMENT``
+environment variable.
+
+.. code-block:: console
+
+   (kayobe) $ source kayobe-env --environment staging
+   (kayobe) $ kayobe control host bootstrap
+
+Finally, an environment name can be specified under
+``$KAYOBE_CONFIG_ROOT/.environment``, which will be used by the ``kayobe-env``
+script if no ``--environment`` argument is used. This is particularly useful
+when using a separate branch for each environment.
+
+.. code-block:: console
+
+   (kayobe) $ echo "staging" > .environment
+   (kayobe) $ source kayobe-env
+   (kayobe) $ kayobe control host bootstrap
+
+.. warning::
+
+   The locations of the Kolla Ansible source code and Python virtual
+   environment remain the same for all environments when using the
+   ``kayobe-env`` file. When using the same control host to manage multiple
+   environments with different versions of Kolla Ansible, clone the Kayobe
+   configuration in different locations, so that Kolla Ansible source
+   repositories and Python virtual environments will not conflict with each
+   other. The generated Kolla Ansible configuration is also shared: Kayobe will
+   store the name of the active environment under
+   ``$KOLLA_CONFIG_PATH/.environment`` and produce a warning if a conflict is
+   detected.
+
+Migrating to Kayobe Environments
+================================
+
+Kayobe users already managing multiple environments will already have multiple
+Kayobe configurations, whether in separate repositories or in different
+branches of the same repository. Kayobe provides the ``kayobe environment
+create`` command to help migrating to a common repository and branch with
+multiple environments. For example, the following commands will create two new
+environments for production and staging based on existing Kayobe
+configurations.
+
+.. code-block:: console
+
+   (kayobe) $ kayobe environment create --source-config-path ~/kayobe-config-prod/etc/kayobe \
+                  --environment production
+   (kayobe) $ kayobe environment create --source-config-path ~/kayobe-config-staging/etc/kayobe \
+                  --environment staging
+
+This command recursively copies files and directories under the existing
+configuration. Merging shared configuration must be done manually.

--- a/doc/source/multiple-environments.rst
+++ b/doc/source/multiple-environments.rst
@@ -261,5 +261,6 @@ configurations.
    (kayobe) $ kayobe environment create --source-config-path ~/kayobe-config-staging/etc/kayobe \
                   --environment staging
 
-This command recursively copies files and directories under the existing
-configuration. Merging shared configuration must be done manually.
+This command recursively copies files and directories (except the
+``environments`` directory if one exists) under the existing configuration to a
+new environment. Merging shared configuration must be done manually.

--- a/etc/kayobe/globals.yml
+++ b/etc/kayobe/globals.yml
@@ -4,8 +4,18 @@
 ###############################################################################
 # Local path configuration (Ansible control host).
 
-# Path to Kayobe configuration directory on Ansible control host.
+# Path to Kayobe configuration directory on Ansible control host, with an
+# environment path appended if kayobe_environment is set.
 #kayobe_config_path:
+
+# Name of Kayobe environment to use. Default is $KAYOBE_ENVIRONMENT, or an
+# empty string if $KAYOBE_ENVIRONMENT is not set. Can also be set via the
+# --environment argument when invoking kayobe.
+#kayobe_environment:
+
+# Path to Kayobe configuration directory on Ansible control host with an
+# environment path appended if kayobe_environment is set.
+#kayobe_env_config_path:
 
 ###############################################################################
 # Remote path configuration (seed, seed-hypervisor and overcloud hosts).

--- a/etc/kayobe/seed.yml
+++ b/etc/kayobe/seed.yml
@@ -92,8 +92,8 @@
 #   squid:
 #     name: "squid"
 #     image: "stackhpc/squid:3.5.20-1"
-#     pre: "{{ kayobe_config_path }}/containers/squid/pre.yml"
-#     post: "{{ kayobe_config_path }}/containers/squid/post.yml"
+#     pre: "{{ kayobe_env_config_path }}/containers/squid/pre.yml"
+#     post: "{{ kayobe_env_config_path }}/containers/squid/post.yml"
 #
 #seed_containers:
 

--- a/kayobe/ansible.py
+++ b/kayobe/ansible.py
@@ -90,8 +90,19 @@ def _get_inventories_paths(parsed_args, env_path):
     if parsed_args.inventory:
         return parsed_args.inventory
     else:
-        return [os.path.join(env_path if env_path else parsed_args.config_path,
-                             "inventory")]
+        inventories = []
+        shared_inventory = os.path.join(parsed_args.config_path, "inventory")
+        if env_path:
+            if os.path.exists(shared_inventory):
+                inventories.append(shared_inventory)
+            env_inventory = os.path.join(env_path, "inventory")
+            if os.path.exists(env_inventory):
+                inventories.append(env_inventory)
+        else:
+            # Preserve existing behaviour: don't check if an inventory
+            # directory exists when no environment is specified
+            inventories.append(shared_inventory)
+        return inventories
 
 
 def _validate_args(parsed_args, playbooks):

--- a/kayobe/ansible.py
+++ b/kayobe/ansible.py
@@ -30,12 +30,15 @@ DEFAULT_CONFIG_PATH = "/etc/kayobe"
 
 CONFIG_PATH_ENV = "KAYOBE_CONFIG_PATH"
 
+ENVIRONMENT_ENV = "KAYOBE_ENVIRONMENT"
+
 LOG = logging.getLogger(__name__)
 
 
 def add_args(parser):
     """Add arguments required for running Ansible playbooks to a parser."""
     default_config_path = os.getenv(CONFIG_PATH_ENV, DEFAULT_CONFIG_PATH)
+    default_environment = os.getenv(ENVIRONMENT_ENV)
     parser.add_argument("-b", "--become", action="store_true",
                         help="run operations with become (nopasswd implied)")
     parser.add_argument("-C", "--check", action="store_true",
@@ -45,6 +48,9 @@ def add_args(parser):
                         help="path to Kayobe configuration. "
                              "(default=$%s or %s)" %
                              (CONFIG_PATH_ENV, DEFAULT_CONFIG_PATH))
+    parser.add_argument("--environment", default=default_environment,
+                        help="specify environment name (default=$%s or None)" %
+                             ENVIRONMENT_ENV)
     parser.add_argument("-e", "--extra-vars", metavar="EXTRA_VARS",
                         action="append",
                         help="set additional variables as key=value or "
@@ -68,12 +74,23 @@ def add_args(parser):
                              "note this has no affect on kolla-ansible.")
 
 
-def _get_inventory_path(parsed_args):
+def _get_kayobe_environment_path(parsed_args):
+    """Return the path to the Kayobe environment or None if not specified."""
+    env_path = None
+    if parsed_args.environment:
+        # Specified via --environment or KAYOBE_ENVIRONMENT.
+        kc_environments = os.path.join(parsed_args.config_path, "environments")
+        env_path = os.path.join(kc_environments, parsed_args.environment)
+    return env_path
+
+
+def _get_inventory_path(parsed_args, env_path):
     """Return the path to the Kayobe inventory."""
     if parsed_args.inventory:
         return parsed_args.inventory
     else:
-        return os.path.join(parsed_args.config_path, "inventory")
+        return os.path.join(env_path if env_path else parsed_args.config_path,
+                            "inventory")
 
 
 def _validate_args(parsed_args, playbooks):
@@ -85,7 +102,15 @@ def _validate_args(parsed_args, playbooks):
                   parsed_args.config_path, result["message"])
         sys.exit(1)
 
-    inventory = _get_inventory_path(parsed_args)
+    env_path = _get_kayobe_environment_path(parsed_args)
+    if env_path:
+        result = utils.is_readable_dir(env_path)
+        if not result["result"]:
+            LOG.error("Kayobe environment %s is invalid: %s",
+                      env_path, result["message"])
+            sys.exit(1)
+
+    inventory = _get_inventory_path(parsed_args, env_path)
     result = utils.is_readable_dir(inventory)
     if not result["result"]:
         LOG.error("Kayobe inventory %s is invalid: %s",
@@ -100,19 +125,25 @@ def _validate_args(parsed_args, playbooks):
             sys.exit(1)
 
 
-def _get_vars_files(config_path):
+def _get_vars_files(vars_paths):
     """Return a list of Kayobe Ansible configuration variable files.
 
-    The files will be sorted alphabetically by name.
+    The list of directories given as argument is searched to create the list of
+    variable files. The files will be sorted alphabetically by name for each
+    directory, but ordering of directories is kept to allow overrides.
     """
     vars_files = []
-    for vars_file in os.listdir(config_path):
-        abs_path = os.path.join(config_path, vars_file)
-        if utils.is_readable_file(abs_path)["result"]:
-            root, ext = os.path.splitext(vars_file)
-            if ext in (".yml", ".yaml", ".json"):
-                vars_files.append(abs_path)
-    return sorted(vars_files)
+    for vars_path in vars_paths:
+        path_vars_files = []
+        for vars_file in os.listdir(vars_path):
+            abs_path = os.path.join(vars_path, vars_file)
+            if utils.is_readable_file(abs_path)["result"]:
+                root, ext = os.path.splitext(vars_file)
+                if ext in (".yml", ".yaml", ".json"):
+                    path_vars_files.append(abs_path)
+        vars_files += sorted(path_vars_files)
+
+    return vars_files
 
 
 def build_args(parsed_args, playbooks,
@@ -125,9 +156,13 @@ def build_args(parsed_args, playbooks,
     if list_tasks or (parsed_args.list_tasks and list_tasks is None):
         cmd += ["--list-tasks"]
     cmd += vault.build_args(parsed_args, "--vault-password-file")
-    inventory = _get_inventory_path(parsed_args)
+    env_path = _get_kayobe_environment_path(parsed_args)
+    inventory = _get_inventory_path(parsed_args, env_path)
     cmd += ["--inventory", inventory]
-    vars_files = _get_vars_files(parsed_args.config_path)
+    vars_paths = [parsed_args.config_path]
+    if env_path:
+        vars_paths.append(env_path)
+    vars_files = _get_vars_files(vars_paths)
     for vars_file in vars_files:
         cmd += ["-e", "@%s" % vars_file]
     if parsed_args.extra_vars:
@@ -164,6 +199,10 @@ def _get_environment(parsed_args):
     # the environment variable is set, so that it can be referenced by
     # playbooks.
     env.setdefault(CONFIG_PATH_ENV, parsed_args.config_path)
+    # If an environment has been specified via --environment, ensure the
+    # environment variable is set, so that it can be referenced by playbooks.
+    if parsed_args.environment:
+        env.setdefault(ENVIRONMENT_ENV, parsed_args.environment)
     # If a custom Ansible configuration file exists, use it.
     ansible_cfg_path = os.path.join(parsed_args.config_path, "ansible.cfg")
     if utils.is_readable_file(ansible_cfg_path)["result"]:
@@ -291,6 +330,7 @@ def prune_galaxy_roles(parsed_args):
 
 def passwords_yml_exists(parsed_args):
     """Return whether passwords.yml exists in the kayobe configuration."""
-    passwords_path = os.path.join(parsed_args.config_path,
-                                  'kolla', 'passwords.yml')
+    env_path = _get_kayobe_environment_path(parsed_args)
+    path = env_path if env_path else parsed_args.config_path
+    passwords_path = os.path.join(path, 'kolla', 'passwords.yml')
     return utils.is_readable_file(passwords_path)["result"]

--- a/kayobe/ansible.py
+++ b/kayobe/ansible.py
@@ -56,6 +56,7 @@ def add_args(parser):
                         help="set additional variables as key=value or "
                              "YAML/JSON")
     parser.add_argument("-i", "--inventory", metavar="INVENTORY",
+                        action="append",
                         help="specify inventory host path "
                              "(default=$%s/inventory or %s/inventory) " %
                              (CONFIG_PATH_ENV, DEFAULT_CONFIG_PATH))
@@ -84,13 +85,13 @@ def _get_kayobe_environment_path(parsed_args):
     return env_path
 
 
-def _get_inventory_path(parsed_args, env_path):
-    """Return the path to the Kayobe inventory."""
+def _get_inventories_paths(parsed_args, env_path):
+    """Return the paths to the Kayobe inventories."""
     if parsed_args.inventory:
         return parsed_args.inventory
     else:
-        return os.path.join(env_path if env_path else parsed_args.config_path,
-                            "inventory")
+        return [os.path.join(env_path if env_path else parsed_args.config_path,
+                             "inventory")]
 
 
 def _validate_args(parsed_args, playbooks):
@@ -110,12 +111,13 @@ def _validate_args(parsed_args, playbooks):
                       env_path, result["message"])
             sys.exit(1)
 
-    inventory = _get_inventory_path(parsed_args, env_path)
-    result = utils.is_readable_dir(inventory)
-    if not result["result"]:
-        LOG.error("Kayobe inventory %s is invalid: %s",
-                  inventory, result["message"])
-        sys.exit(1)
+    inventories = _get_inventories_paths(parsed_args, env_path)
+    for inventory in inventories:
+        result = utils.is_readable_dir(inventory)
+        if not result["result"]:
+            LOG.error("Kayobe inventory %s is invalid: %s",
+                      inventory, result["message"])
+            sys.exit(1)
 
     for playbook in playbooks:
         result = utils.is_readable_file(playbook)
@@ -157,8 +159,9 @@ def build_args(parsed_args, playbooks,
         cmd += ["--list-tasks"]
     cmd += vault.build_args(parsed_args, "--vault-password-file")
     env_path = _get_kayobe_environment_path(parsed_args)
-    inventory = _get_inventory_path(parsed_args, env_path)
-    cmd += ["--inventory", inventory]
+    inventories = _get_inventories_paths(parsed_args, env_path)
+    for inventory in inventories:
+        cmd += ["--inventory", inventory]
     vars_paths = [parsed_args.config_path]
     if env_path:
         vars_paths.append(env_path)

--- a/kayobe/cli/commands.py
+++ b/kayobe/cli/commands.py
@@ -21,6 +21,7 @@ from cliff.command import Command
 from cliff.hooks import CommandHook
 
 from kayobe import ansible
+from kayobe import environment
 from kayobe import kolla_ansible
 from kayobe import utils
 from kayobe import vault
@@ -1691,3 +1692,34 @@ class BaremetalComputeUpdateDeploymentImage(KayobeAnsibleMixin, VaultMixin,
             )
         self.run_kayobe_playbooks(parsed_args, playbooks,
                                   extra_vars=extra_vars)
+
+
+class EnvironmentCreate(KayobeAnsibleMixin, VaultMixin, Command):
+    """Create a new Kayobe environment."""
+
+    def get_parser(self, prog_name):
+        parser = super(EnvironmentCreate, self).get_parser(prog_name)
+        group = parser.add_argument_group("Kayobe Environments")
+        environment.add_args(group)
+        return parser
+
+    def take_action(self, parsed_args):
+        self.app.LOG.debug("Creating new Kayobe environment")
+        if not parsed_args.environment:
+            self.app.LOG.error("An environment must be specified")
+            sys.exit(1)
+
+        source_config_path = parsed_args.source_config_path
+        if source_config_path:
+            result = utils.is_readable_dir(source_config_path)
+            if not result["result"]:
+                self.app.LOG.error("Kayobe configuration %s is invalid: %s",
+                                   source_config_path, result["message"])
+                sys.exit(1)
+
+        try:
+            environment.create_kayobe_environment(parsed_args)
+        except Exception as e:
+            self.app.LOG.error("Failed to create environment %s: %s",
+                               parsed_args.environment, repr(e))
+            sys.exit(1)

--- a/kayobe/environment.py
+++ b/kayobe/environment.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2021 StackHPC Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+import os
+import os.path
+import sys
+
+from kayobe import utils
+
+
+LOG = logging.getLogger(__name__)
+
+
+def add_args(parser):
+    """Add arguments required for managing Kayobe environments to a parser."""
+    parser.add_argument("--source-config-path",
+                        help="Kayobe configuration to import")
+
+
+def create_kayobe_environment(parsed_args):
+    """Create a new Kayobe environment."""
+    if not parsed_args.environment:
+        LOG.error("You must specify an environment to create")
+        sys.exit(1)
+
+    # Ensure environments directory exists and is readable inside config path
+    kc_environments = os.path.join(parsed_args.config_path, "environments")
+    result = utils.is_readable_dir(kc_environments)
+    if not result["result"]:
+        if result["message"] == "Path does not exist":
+            os.mkdir(kc_environments)
+        else:
+            LOG.error("Kayobe global environments directory %s is invalid: %s",
+                      kc_environments, result["message"])
+            sys.exit(1)
+
+    env_path = os.path.join(kc_environments, parsed_args.environment)
+    result = utils.is_readable_dir(env_path)
+    if result["result"]:
+        LOG.error("Kayobe environment directory %s already exists", env_path)
+        sys.exit(1)
+    else:
+        if result["message"] == "Path does not exist":
+            os.mkdir(env_path)
+        else:
+            LOG.error("Kayobe environment directory %s is invalid: %s",
+                      env_path, result["message"])
+            sys.exit(1)
+
+    source_config_path = parsed_args.source_config_path
+    if source_config_path:
+        utils.copy_dir(source_config_path, env_path)

--- a/kayobe/environment.py
+++ b/kayobe/environment.py
@@ -61,4 +61,4 @@ def create_kayobe_environment(parsed_args):
 
     source_config_path = parsed_args.source_config_path
     if source_config_path:
-        utils.copy_dir(source_config_path, env_path)
+        utils.copy_dir(source_config_path, env_path, exclude=["environments"])

--- a/kayobe/tests/unit/test_ansible.py
+++ b/kayobe/tests/unit/test_ansible.py
@@ -52,7 +52,7 @@ class TestCase(unittest.TestCase):
         expected_env = {"KAYOBE_CONFIG_PATH": "/etc/kayobe"}
         mock_run.assert_called_once_with(expected_cmd, check_output=False,
                                          quiet=False, env=expected_env)
-        mock_vars.assert_called_once_with("/etc/kayobe")
+        mock_vars.assert_called_once_with(["/etc/kayobe"])
 
     @mock.patch.object(utils, "run_command")
     @mock.patch.object(ansible, "_get_vars_files")
@@ -68,6 +68,7 @@ class TestCase(unittest.TestCase):
             "-b",
             "-C",
             "--config-path", "/path/to/config",
+            "--environment", "test-env",
             "-e", "ev_name1=ev_value1",
             "-i", "/path/to/inventory",
             "-l", "group1:host",
@@ -92,10 +93,12 @@ class TestCase(unittest.TestCase):
             "playbook1.yml",
             "playbook2.yml",
         ]
-        expected_env = {"KAYOBE_CONFIG_PATH": "/path/to/config"}
+        expected_env = {"KAYOBE_CONFIG_PATH": "/path/to/config",
+                        "KAYOBE_ENVIRONMENT": "test-env"}
         mock_run.assert_called_once_with(expected_cmd, check_output=False,
                                          quiet=False, env=expected_env)
-        mock_vars.assert_called_once_with("/path/to/config")
+        mock_vars.assert_called_once_with(
+            ["/path/to/config", "/path/to/config/environments/test-env"])
 
     @mock.patch.object(utils, "run_command")
     @mock.patch.object(ansible, "_get_vars_files")
@@ -114,6 +117,7 @@ class TestCase(unittest.TestCase):
             "--become",
             "--check",
             "--config-path", "/path/to/config",
+            "--environment", "test-env",
             "--extra-vars", "ev_name1=ev_value1",
             "--inventory", "/path/to/inventory",
             "--limit", "group1:host1",
@@ -141,6 +145,7 @@ class TestCase(unittest.TestCase):
             "playbook2.yml",
         ]
         expected_env = {"KAYOBE_CONFIG_PATH": "/path/to/config",
+                        "KAYOBE_ENVIRONMENT": "test-env",
                         "KAYOBE_VAULT_PASSWORD": "test-pass"}
         expected_calls = [
             mock.call(["which", "kayobe-vault-password-helper"],
@@ -149,7 +154,8 @@ class TestCase(unittest.TestCase):
                       env=expected_env)
         ]
         self.assertEqual(expected_calls, mock_run.mock_calls)
-        mock_vars.assert_called_once_with("/path/to/config")
+        mock_vars.assert_called_once_with(
+            ["/path/to/config", "/path/to/config/environments/test-env"])
 
     @mock.patch.object(utils, "run_command")
     @mock.patch.object(ansible, "_get_vars_files")
@@ -262,7 +268,7 @@ class TestCase(unittest.TestCase):
         expected_env = {"KAYOBE_CONFIG_PATH": "/etc/kayobe"}
         mock_run.assert_called_once_with(expected_cmd, check_output=False,
                                          quiet=False, env=expected_env)
-        mock_vars.assert_called_once_with("/etc/kayobe")
+        mock_vars.assert_called_once_with(["/etc/kayobe"])
 
     @mock.patch.object(utils, "run_command")
     @mock.patch.object(ansible, "_get_vars_files")
@@ -291,7 +297,7 @@ class TestCase(unittest.TestCase):
         expected_env = {"KAYOBE_CONFIG_PATH": "/etc/kayobe"}
         mock_run.assert_called_once_with(expected_cmd, check_output=False,
                                          quiet=False, env=expected_env)
-        mock_vars.assert_called_once_with("/etc/kayobe")
+        mock_vars.assert_called_once_with(["/etc/kayobe"])
 
     @mock.patch.object(utils, "run_command")
     @mock.patch.object(ansible, "_get_vars_files")
@@ -320,7 +326,7 @@ class TestCase(unittest.TestCase):
         expected_env = {"KAYOBE_CONFIG_PATH": "/etc/kayobe"}
         mock_run.assert_called_once_with(expected_cmd, check_output=False,
                                          quiet=False, env=expected_env)
-        mock_vars.assert_called_once_with("/etc/kayobe")
+        mock_vars.assert_called_once_with(["/etc/kayobe"])
 
     @mock.patch.object(utils, "run_command")
     @mock.patch.object(utils, "is_readable_file")
@@ -346,7 +352,7 @@ class TestCase(unittest.TestCase):
         }
         mock_run.assert_called_once_with(expected_cmd, check_output=False,
                                          quiet=False, env=expected_env)
-        mock_vars.assert_called_once_with("/etc/kayobe")
+        mock_vars.assert_called_once_with(["/etc/kayobe"])
         mock_readable.assert_called_once_with("/etc/kayobe/ansible.cfg")
 
     @mock.patch.object(utils, "run_command")
@@ -374,7 +380,7 @@ class TestCase(unittest.TestCase):
         }
         mock_run.assert_called_once_with(expected_cmd, check_output=False,
                                          quiet=False, env=expected_env)
-        mock_vars.assert_called_once_with("/etc/kayobe")
+        mock_vars.assert_called_once_with(["/etc/kayobe"])
         mock_readable.assert_called_once_with("/etc/kayobe/ansible.cfg")
 
     @mock.patch.object(utils, "run_command")

--- a/kayobe/tests/unit/test_ansible.py
+++ b/kayobe/tests/unit/test_ansible.py
@@ -588,3 +588,121 @@ class TestCase(unittest.TestCase):
         mock_run.assert_called_once_with(expected_cmd, check_output=False,
                                          quiet=False, env=expected_env)
         mock_vars.assert_called_once_with(["/etc/kayobe"])
+
+    @mock.patch.object(os.path, "exists")
+    @mock.patch.object(utils, "run_command")
+    @mock.patch.object(ansible, "_get_vars_files")
+    @mock.patch.object(ansible, "_validate_args")
+    def test_multiple_inventories(self, mock_validate, mock_vars, mock_run,
+                                  mock_exists):
+        mock_vars.return_value = []
+        # os.path.exists gets called three times:
+        # 1) shared inventory
+        # 2) environment inventory
+        # 3) ansible.cfg
+        mock_exists.side_effect = [True, True, False]
+        parser = argparse.ArgumentParser()
+        ansible.add_args(parser)
+        vault.add_args(parser)
+        args = [
+            "--environment", "test-env",
+        ]
+        parsed_args = parser.parse_args(args)
+        ansible.run_playbooks(parsed_args, ["playbook1.yml", "playbook2.yml"])
+        expected_cmd = [
+            "ansible-playbook",
+            "--inventory", "/etc/kayobe/inventory",
+            "--inventory", "/etc/kayobe/environments/test-env/inventory",
+            "playbook1.yml",
+            "playbook2.yml",
+        ]
+        expected_env = {"KAYOBE_CONFIG_PATH": "/etc/kayobe",
+                        "KAYOBE_ENVIRONMENT": "test-env"}
+        expected_calls = [
+            mock.call("/etc/kayobe/inventory"),
+            mock.call("/etc/kayobe/environments/test-env/inventory"),
+            mock.call("/etc/kayobe/ansible.cfg"),
+        ]
+        self.assertEqual(expected_calls, mock_exists.mock_calls)
+        mock_run.assert_called_once_with(expected_cmd, check_output=False,
+                                         quiet=False, env=expected_env)
+        mock_vars.assert_called_once_with(
+            ["/etc/kayobe", "/etc/kayobe/environments/test-env"])
+
+    @mock.patch.object(os.path, "exists")
+    @mock.patch.object(utils, "run_command")
+    @mock.patch.object(ansible, "_get_vars_files")
+    @mock.patch.object(ansible, "_validate_args")
+    def test_shared_inventory_only(self, mock_validate, mock_vars, mock_run,
+                                   mock_exists):
+        mock_vars.return_value = []
+        # os.path.exists gets called three times:
+        # 1) shared inventory
+        # 2) environment inventory
+        # 3) ansible.cfg
+        mock_exists.side_effect = [True, False, False]
+        parser = argparse.ArgumentParser()
+        ansible.add_args(parser)
+        vault.add_args(parser)
+        args = [
+            "--environment", "test-env",
+        ]
+        parsed_args = parser.parse_args(args)
+        ansible.run_playbooks(parsed_args, ["playbook1.yml", "playbook2.yml"])
+        expected_cmd = [
+            "ansible-playbook",
+            "--inventory", "/etc/kayobe/inventory",
+            "playbook1.yml",
+            "playbook2.yml",
+        ]
+        expected_env = {"KAYOBE_CONFIG_PATH": "/etc/kayobe",
+                        "KAYOBE_ENVIRONMENT": "test-env"}
+        expected_calls = [
+            mock.call("/etc/kayobe/inventory"),
+            mock.call("/etc/kayobe/environments/test-env/inventory"),
+            mock.call("/etc/kayobe/ansible.cfg"),
+        ]
+        self.assertEqual(expected_calls, mock_exists.mock_calls)
+        mock_run.assert_called_once_with(expected_cmd, check_output=False,
+                                         quiet=False, env=expected_env)
+        mock_vars.assert_called_once_with(
+            ["/etc/kayobe", "/etc/kayobe/environments/test-env"])
+
+    @mock.patch.object(os.path, "exists")
+    @mock.patch.object(utils, "run_command")
+    @mock.patch.object(ansible, "_get_vars_files")
+    @mock.patch.object(ansible, "_validate_args")
+    def test_env_inventory_only(self, mock_validate, mock_vars, mock_run,
+                                mock_exists):
+        mock_vars.return_value = []
+        # os.path.exists gets called three times:
+        # 1) shared inventory
+        # 2) environment inventory
+        # 3) ansible.cfg
+        mock_exists.side_effect = [False, True, False]
+        parser = argparse.ArgumentParser()
+        ansible.add_args(parser)
+        vault.add_args(parser)
+        args = [
+            "--environment", "test-env",
+        ]
+        parsed_args = parser.parse_args(args)
+        ansible.run_playbooks(parsed_args, ["playbook1.yml", "playbook2.yml"])
+        expected_cmd = [
+            "ansible-playbook",
+            "--inventory", "/etc/kayobe/environments/test-env/inventory",
+            "playbook1.yml",
+            "playbook2.yml",
+        ]
+        expected_env = {"KAYOBE_CONFIG_PATH": "/etc/kayobe",
+                        "KAYOBE_ENVIRONMENT": "test-env"}
+        expected_calls = [
+            mock.call("/etc/kayobe/inventory"),
+            mock.call("/etc/kayobe/environments/test-env/inventory"),
+            mock.call("/etc/kayobe/ansible.cfg"),
+        ]
+        self.assertEqual(expected_calls, mock_exists.mock_calls)
+        mock_run.assert_called_once_with(expected_cmd, check_output=False,
+                                         quiet=False, env=expected_env)
+        mock_vars.assert_called_once_with(
+            ["/etc/kayobe", "/etc/kayobe/environments/test-env"])

--- a/kayobe/tests/unit/test_ansible.py
+++ b/kayobe/tests/unit/test_ansible.py
@@ -562,3 +562,29 @@ class TestCase(unittest.TestCase):
         self.assertTrue(result)
         mock_is_readable.assert_called_once_with(
             "/path/to/config/kolla/passwords.yml")
+
+    @mock.patch.object(utils, "run_command")
+    @mock.patch.object(ansible, "_get_vars_files")
+    @mock.patch.object(ansible, "_validate_args")
+    def test_multiple_inventory_args(self, mock_validate, mock_vars, mock_run):
+        mock_vars.return_value = []
+        parser = argparse.ArgumentParser()
+        ansible.add_args(parser)
+        vault.add_args(parser)
+        args = [
+            "--inventory", "/etc/kayobe/inventory",
+            "--inventory", "/etc/kayobe/environments/foobar/inventory",
+        ]
+        parsed_args = parser.parse_args(args)
+        ansible.run_playbooks(parsed_args, ["playbook1.yml", "playbook2.yml"])
+        expected_cmd = [
+            "ansible-playbook",
+            "--inventory", "/etc/kayobe/inventory",
+            "--inventory", "/etc/kayobe/environments/foobar/inventory",
+            "playbook1.yml",
+            "playbook2.yml",
+        ]
+        expected_env = {"KAYOBE_CONFIG_PATH": "/etc/kayobe"}
+        mock_run.assert_called_once_with(expected_cmd, check_output=False,
+                                         quiet=False, env=expected_env)
+        mock_vars.assert_called_once_with(["/etc/kayobe"])

--- a/kayobe/tests/unit/test_environment.py
+++ b/kayobe/tests/unit/test_environment.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2021 StackHPC Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import argparse
+import os
+import unittest
+from unittest import mock
+
+from kayobe import ansible
+from kayobe import environment
+from kayobe import utils
+
+
+class TestCase(unittest.TestCase):
+
+    @mock.patch.object(utils, "is_readable_dir")
+    def test_unreadable_environments_directory(self, mock_readable_dir):
+        mock_readable_dir.return_value = {
+            "result": False,
+            "message": "Directory is not readable"
+        }
+        parser = argparse.ArgumentParser()
+        args = [
+            "--config-path", "/path/to/config",
+            "--environment", "foo",
+        ]
+        ansible.add_args(parser)
+        environment.add_args(parser)
+        parsed_args = parser.parse_args(args)
+        self.assertRaises(SystemExit,
+                          environment.create_kayobe_environment, parsed_args)
+
+    @mock.patch.object(utils, "is_readable_dir")
+    def test_environment_exists(self, mock_readable_dir):
+        mock_readable_dir.side_effect = [{"result": True}, {"result": True}]
+        parser = argparse.ArgumentParser()
+        args = [
+            "--config-path", "/path/to/config",
+            "--environment", "foo",
+        ]
+        ansible.add_args(parser)
+        environment.add_args(parser)
+        parsed_args = parser.parse_args(args)
+        self.assertRaises(SystemExit,
+                          environment.create_kayobe_environment, parsed_args)
+
+    @mock.patch.object(utils, "copy_dir")
+    @mock.patch.object(os, "mkdir")
+    @mock.patch.object(utils, "is_readable_dir")
+    def test_create_kayobe_environment(self, mock_readable_dir, mock_mkdir,
+                                       mock_copy_dir):
+        mock_readable_dir.return_value = {
+            "result": False,
+            "message": "Path does not exist"
+        }
+        parser = argparse.ArgumentParser()
+        args = [
+            "--config-path", "/path/to/config",
+            "--source-config-path", "/path/to/foo",
+            "--environment", "foo",
+        ]
+        ansible.add_args(parser)
+        environment.add_args(parser)
+        parsed_args = parser.parse_args(args)
+        environment.create_kayobe_environment(parsed_args)
+        expected_calls = [
+            mock.call("/path/to/config/environments"),
+            mock.call("/path/to/config/environments/foo"),
+        ]
+        self.assertEqual(expected_calls, mock_mkdir.call_args_list)
+        mock_copy_dir.assert_called_once_with(
+            "/path/to/foo", "/path/to/config/environments/foo")

--- a/kayobe/tests/unit/test_environment.py
+++ b/kayobe/tests/unit/test_environment.py
@@ -80,4 +80,5 @@ class TestCase(unittest.TestCase):
         ]
         self.assertEqual(expected_calls, mock_mkdir.call_args_list)
         mock_copy_dir.assert_called_once_with(
-            "/path/to/foo", "/path/to/config/environments/foo")
+            "/path/to/foo", "/path/to/config/environments/foo",
+            exclude=["environments"])

--- a/kayobe/utils.py
+++ b/kayobe/utils.py
@@ -225,14 +225,27 @@ def intersect_limits(args_limit, cli_limit):
     return separator.join(limits)
 
 
-def copy_dir(src, dest):
+def copy_dir(src, dest, exclude=None):
+    """Copy recursively a directory.
+
+    :param src: path of the source directory
+    :param dest: destination path, will be created if it does not exist
+    :param exclude: names of files or directories at the root of the source
+                    directory to exclude during copy
+    """
+    if exclude is None:
+        exclude = []
+
     if not os.path.isdir(dest):
-        shutil.copytree(src, dest)
-    else:
-        for file in os.listdir(src):
-            src_path = os.path.join(src, file)
-            dest_path = os.path.join(dest, file)
-            if os.path.isdir(src_path):
-                copy_dir(src_path, dest_path)
-            else:
-                shutil.copy2(src_path, dest_path)
+        os.mkdir(dest)
+
+    for file in os.listdir(src):
+        if file in exclude:
+            continue
+
+        src_path = os.path.join(src, file)
+        dest_path = os.path.join(dest, file)
+        if os.path.isdir(src_path):
+            copy_dir(src_path, dest_path)
+        else:
+            shutil.copy2(src_path, dest_path)

--- a/kayobe/utils.py
+++ b/kayobe/utils.py
@@ -17,6 +17,7 @@ import glob
 import itertools
 import logging
 import os
+import shutil
 import subprocess
 import sys
 
@@ -222,3 +223,16 @@ def intersect_limits(args_limit, cli_limit):
         separator = ':&'
     limits = [l for l in [args_limit, cli_limit] if l]
     return separator.join(limits)
+
+
+def copy_dir(src, dest):
+    if not os.path.isdir(dest):
+        shutil.copytree(src, dest)
+    else:
+        for file in os.listdir(src):
+            src_path = os.path.join(src, file)
+            dest_path = os.path.join(dest, file)
+            if os.path.isdir(src_path):
+                copy_dir(src_path, dest_path)
+            else:
+                shutil.copy2(src_path, dest_path)

--- a/releasenotes/notes/multiple-environments-2961e5ba017822dd.yaml
+++ b/releasenotes/notes/multiple-environments-2961e5ba017822dd.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Adds support for managing multiple Kayobe environments from a single
+    configuration repository. See the `documentation
+    <https://docs.openstack.org/kayobe/latest/multiple-environments.html>`__
+    for more details. Note that this feature is considered experimental: its
+    design may change in future versions without a deprecation period.

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ kayobe.cli=
     control_host_bootstrap = kayobe.cli.commands:ControlHostBootstrap
     control_host_upgrade = kayobe.cli.commands:ControlHostUpgrade
     configuration_dump = kayobe.cli.commands:ConfigurationDump
+    environment_create = kayobe.cli.commands:EnvironmentCreate
     kolla_ansible_run = kayobe.cli.commands:KollaAnsibleRun
     network_connectivity_check = kayobe.cli.commands:NetworkConnectivityCheck
     overcloud_bios_raid_configure = kayobe.cli.commands:OvercloudBIOSRAIDConfigure


### PR DESCRIPTION
Backport of multi-env feature from upstream/master:

 - Add documentation for multiple environments

    Change-Id: Ie74b1ee61d4cfa19ea710153694349c7ea61d78e
    Story: 2002009
    Task: 40039
    (Cherry pick 1a20aa071b135b4a3d7a78824c6e26360c178203)

 - Exit when environment clashes are detected

    When running kolla-ansible using a Kayobe environment, write the
    environment name to $KOLLA_CONFIG_PATH/.environment. In later
    executions, check that the environment name is the same. Warn user to
    clean up $KOLLA_CONFIG_PATH otherwise.

    Change-Id: Ibbb1fdcad4034620ff8fbfe184d803bcc86f53f9
    Story: 2002009
    Task: 42185
    (Cherry pick 18a25fdb0580f0d68c93b2c63de99554034e19a7)

 - Detect multiple inventories automatically

    When inventory arguments are not passed but an environment is specified,
    detect if there are inventory directories present in the shared Kayobe
    configuration directory and in the environment directory. Using
    os.path.exists() is sufficient because we validate these paths later
    with utils.is_readable_dir().

    Change-Id: Ieb2b7ff07cd43029399e9e19002b82940246f8c4
    Story: 2002009
    Task: 41739
    (Cherry pick ea54f822999e6bc43e195f38cfd66caf05fc10ef)

 - Support passing multiple Kayobe inventory arguments

    Change-Id: I875d73cfe056dc505beffdec9bf348b3dc8bd910
    Story: 2002009
    Task: 41738
    (Cherry pick c15ed69b18dfbf4de69d8bf2ca01c934cb4fbf54)

 - Add a command to create a new Kayobe environment

    Change-Id: I2f33bda5f2f84bbbb0f40240d2575a0b69ddceea
    Story: 2002009
    Task: 40038
    (Cherry pick 2bc568debb2a6f7d3e0b28e1568b5f27eded27d3)

 - Support multiple environments from a single configuration

    Change-Id: I848d834aa36943027c126e26e93e4a4680521144
    Story: 2002009
    Task: 40037
    (Cherry picked 14196369301dd6aa41dc897f908610720a4291b0)