### PR TITLE
kolla: Set neutron_plugin_agent to OVN when it's enabled

### DIFF
--- a/ansible/roles/kolla-ansible/templates/globals.yml.j2
+++ b/ansible/roles/kolla-ansible/templates/globals.yml.j2
@@ -114,7 +114,7 @@ docker_custom_config: {{ kolla_docker_custom_config | to_nice_json | indent(2) }
 #dns_address_family: "{% raw %}{{ network_address_family }}{% endraw %}"
 
 # Valid options are [ openvswitch, linuxbridge ]
-neutron_plugin_agent: "openvswitch"
+neutron_plugin_agent: "{% if kolla_enable_ovn | default(False) | bool %}ovn{% else %}openvswitch{% endif %}"
 
 # Valid options are [ internal, infoblox ]
 #neutron_ipam_driver: "internal"

--- a/releasenotes/notes/bugfix-2009080-4c3a5a8acb9de39c.yaml
+++ b/releasenotes/notes/bugfix-2009080-4c3a5a8acb9de39c.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Setting `kolla_enable_ovn` in ``kolla.yml`` did not configure Neutron's
+    integration with OVN.
+    See `story 2009080 <https://storyboard.openstack.org/#!/story/2009080>`__
+    for details.


### PR DESCRIPTION
kolla_enable_ovn currently just builds OVN images and
deploys OVN without configuring Neutron to use OVN.

Story: 2009080
Task: 42892

Change-Id: Ib756630d50cb9cf89342f32bf1d4e07df31b1a62