### PR TITLE
Support for untemplated dirs in kolla config

### DIFF
--- a/ansible/roles/kolla-openstack/tasks/config.yml
+++ b/ansible/roles/kolla-openstack/tasks/config.yml
@@ -114,6 +114,7 @@
     - item.0.item.enabled | bool
     - item.1.path | basename not in item.0.item.ignore | default([])
     - item.1.path | basename not in item.0.item.untemplated | default([])
+    - (item.1.path | dirname | relpath(item.0.item.src)).split("/")[0] not in item.0.item.untemplated_dirs | default([])
 
 - name: Ensure untemplated extra configuration files exist
   copy:
@@ -127,7 +128,8 @@
   when:
     - item.0.item.enabled | bool
     - item.1.path | basename not in item.0.item.ignore | default([])
-    - item.1.path | basename in item.0.item.untemplated | default([])
+    - (item.1.path | basename in item.0.item.untemplated | default([])) or
+      ((item.1.path | dirname | relpath(item.0.item.src)).split("/")[0] in item.0.item.untemplated_dirs | default([]))
 
 - name: Ensure unnecessary extra configuration files are absent
   file:

--- a/ansible/roles/kolla-openstack/vars/main.yml
+++ b/ansible/roles/kolla-openstack/vars/main.yml
@@ -98,6 +98,9 @@ kolla_openstack_custom_config:
     dest: "{{ kolla_node_custom_config_path }}/horizon"
     patterns: "*"
     enabled: "{{ kolla_enable_horizon }}"
+    untemplated_dirs:
+    # Do not attempt to template themes directory.
+      - "themes"
   # InfluxDB.
   - src: "{{ kolla_extra_config_path }}/"
     dest: "{{ kolla_node_custom_config_path }}/"

--- a/releasenotes/notes/add-support-for-custom-horizon-themes-5da1d99c1b8107b9.yaml
+++ b/releasenotes/notes/add-support-for-custom-horizon-themes-5da1d99c1b8107b9.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Adds support for custom Horizon themes.


### PR DESCRIPTION
Variable untemplated_dirs has been added to allow for
defining directories under kayobe/kolla/config which should be copied
instead of templated by kolla-openstack role.

This is needed to support custom themes for horizon -
change If9982c8e18be31772cb031ef72b7eebd4d768be5

Change-Id: I350f58c8a82f0f31608b34054e804c5c198d6806