### PR TITLE
Wallaby backport overcloud DIB upper constraints

### DIFF
--- a/ansible/group_vars/all/overcloud-dib
+++ b/ansible/group_vars/all/overcloud-dib
@@ -52,3 +52,8 @@ overcloud_dib_env_vars: "{{ overcloud_dib_env_vars_default | combine(overcloud_d
 
 # List of DIB packages to install. Default is to install no extra packages.
 overcloud_dib_packages: []
+
+# Upper constraints file for installing packages in the virtual environment
+# used for building overcloud host disk images. Default is {{
+# pip_upper_constraints_file }}.
+overcloud_dib_upper_constraints_file: "{{ pip_upper_constraints_file }}"

--- a/ansible/overcloud-host-image-build.yml
+++ b/ansible/overcloud-host-image-build.yml
@@ -19,7 +19,7 @@
           vars:
             os_images_venv: "{{ virtualenv_path }}/overcloud-host-image-dib"
             os_images_package_state: latest
-            os_images_upper_constraints_file: "{{ pip_upper_constraints_file }}"
+            os_images_upper_constraints_file: "{{ overcloud_dib_upper_constraints_file }}"
             os_images_cache: "{{ image_cache_path }}"
             os_images_common: ""
             os_images_list:

--- a/etc/kayobe/overcloud-dib.yml
+++ b/etc/kayobe/overcloud-dib.yml
@@ -45,6 +45,11 @@
 # List of DIB packages to install. Default is to install no extra packages.
 #overcloud_dib_packages:
 
+# Upper constraints file for installing packages in the virtual environment
+# used for building overcloud host disk images. Default is {{
+# pip_upper_constraints_file }}.
+#overcloud_dib_upper_constraints_file:
+
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.
 workaround_ansible_issue_8743: yes


### PR DESCRIPTION
This variable allows to customise the upper constraints file used to
install packages inside the overcloud-host-image-dib virtual
environment. This can be used when we need a newer version of
diskimage-builder than the one available in upper constraints for the
current release.

Change-Id: I2f6c2f92903815973865ef0f5d6b867d5b995bd5
Story: 2002098
Task: 44101