### PR TITLE
Adds kolla_ansible_venv_ansible

### DIFF
--- a/ansible/roles/kolla-ansible/defaults/main.yml
+++ b/ansible/roles/kolla-ansible/defaults/main.yml
@@ -21,6 +21,11 @@ kolla_ansible_venv_python: python3
 # Extra requirements to install inside the kolla-ansible virtualenv.
 kolla_ansible_venv_extra_requirements: []
 
+# Pip requirement specifier for the ansible package. NOTE: This limits the
+# version of ansible used by kolla-ansible to avoid new releases from breaking
+# tested code. Changes to this limit should be tested.
+kolla_ansible_venv_ansible: 'ansible>=2.9,<2.11,!=2.9.8,!=2.9.12'
+
 # Virtualenv directory where Kolla-ansible's ansible modules will execute
 # remotely on the target nodes. If None, no virtualenv will be used.
 kolla_ansible_target_venv:

--- a/ansible/roles/kolla-ansible/tasks/install.yml
+++ b/ansible/roles/kolla-ansible/tasks/install.yml
@@ -64,10 +64,7 @@
         {% else %}
         kolla-ansible=={{ kolla_openstack_release }}
         {% endif %}
-      # Limit the version of ansible used by kolla-ansible to avoid new
-      # releases from breaking tested code. Changes to this limit should be
-      # tested.
-      - ansible>=2.9,<2.11,!=2.9.8,!=2.9.12
+      - "{{ kolla_ansible_venv_ansible }}"
       - selinux
   pip:
     name: "{{ (kolla_ansible_packages + kolla_ansible_venv_extra_requirements) | select | list }}"

--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -50,6 +50,11 @@
 # Extra requirements to install inside the kolla-ansible virtualenv.
 #kolla_ansible_venv_extra_requirements:
 
+# Pip requirement specifier for the ansible package. NOTE: This limits the
+# version of ansible used by kolla-ansible to avoid new releases from breaking
+# tested code. Changes to this limit should be tested.
+#kolla_ansible_venv_ansible:
+
 # Path to Kolla-ansible configuration directory. Default is $KOLLA_CONFIG_PATH
 # or /etc/kolla if $KOLLA_CONFIG_PATH is not set.
 #kolla_config_path:

--- a/releasenotes/notes/adds-ansible-requirement-specifier-728e3045fc448715.yaml
+++ b/releasenotes/notes/adds-ansible-requirement-specifier-728e3045fc448715.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Adds the ``kolla_ansible_venv_ansible`` configuration option. This allows
+    you to override the version of ansible installed in the kolla-ansible
+    virtualenv.


### PR DESCRIPTION
This adds a variable that allows you to modify the version of ansible
installed in the kolla-ansible virtualenv. This is useful if you want
to use a customised version of ansible.

Cherry-pick amended with wallaby ansible versions and collection
installation related variable removed

Change-Id: I319dd51ed3221826f820fbc0ae3639b89e9c82ea
(cherry picked from commit 1375517d2b39ecbba539d05749cc01bf8d1114bf)